### PR TITLE
Rename to `convertBytesToKb`, Fix help output, Fix typos

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Anyway, you are sincerely welcome. I will try to explain the recommended guideli
 
 - Following this protocol helps to avoid working in vain. It would be a shame to dedicate hours to a pull request and have to reject it because there is already someone working on a similar issue.
 
--Unless they are minor and fast moficications, try to let everyone know that you are modifying something by opening an issue for example, or consulting the [projects](https://github.com/voidcosmos/npkill/projects)
+- Unless they are minor and fast modifications, try to let everyone know that you are modifying something by opening an issue for example, or consulting the [projects](https://github.com/voidcosmos/npkill/projects)
 
 - Change only the necessary lines for your modification. This will help to avoid conflicts, and in case of there being any, it will be easier to solve them.
 
@@ -25,7 +25,7 @@ Anyway, you are sincerely welcome. I will try to explain the recommended guideli
 
 2. Then, open an issue explaining what you want to incorporate, and the files that you think you will need to modify a priori.
 
-3. Wait for the community to give a opinion, and for some member to approve your proposal (a decision that will be taken into the community and future plans).
+3. Wait for the community to give an opinion, and for some member to approve your proposal (a decision that will be taken into the community and future plans).
 
 Yay! Green light to work!
 

--- a/README.MD
+++ b/README.MD
@@ -92,7 +92,7 @@ To exit, <kbd>Q</kbd> or <kbd>Ctrl</kbd> + <kbd>c</kbd> if you're brave.
 | -f, --full             | Start searching from the home of the user (example: "/home/user" in linux)                                                                     |
 | -gb                    | Show folders in Gigabytes instead of Megabytes.                                                                                                |
 | -h, --help, ?          | Show this help page and exit                                                                                                                   |
-| -nu, --no-check-update | Dont check for updates on startup                                                                                                              |
+| -nu, --no-check-update | Don't check for updates on startup                                                                                                              |
 | -s, --sort             | Sort results by: size or path _[ beta ]_                                                                                                       |
 | -t, --target           | Specify the name of the directories you want to search (by default, is node_modules)                                                           |
 | -v, --version          | Show npkill version                                                                                                                            |
@@ -113,7 +113,7 @@ cd ~/projects
 npkill
 ```
 
-- List directories named "dist" and and show errors if any occur:
+- List directories named "dist" and show errors if any occur:
 
 ```bash
 npkill --target dist -e

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -150,6 +150,11 @@ export class Controller {
         ++lineCount;
       });
     });
+
+    this.printAt('', {
+      x: 0,
+      y: lineCount * 2 + 2,
+    });
   }
 
   private showProgramVersion(): void {

--- a/src/interfaces/file-service.interface.ts
+++ b/src/interfaces/file-service.interface.ts
@@ -6,7 +6,7 @@ export interface IFileService {
   listDir(params: IListDirParams): Observable<{}>;
   deleteDir(path: string): Promise<{}>;
   convertKbToGb(kb: number): number;
-  convertBToKb(bytes: number): number;
+  convertBytesToKb(bytes: number): number;
   convertGbToMb(gb: number): number;
   getFileContent(path: string): string;
   isSafeToDelete(path: string, targetFolder: string): boolean;

--- a/src/services/files.service.ts
+++ b/src/services/files.service.ts
@@ -14,9 +14,9 @@ export abstract class FileService implements IFileService {
     return kb / factorKbtoGb;
   }
 
-  convertBToKb(bytes: number): number {
-    const factorBtoGb = 1024;
-    return bytes / factorBtoGb;
+  convertBytesToKb(bytes: number): number {
+    const factorBytestoKb = 1024;
+    return bytes / factorBytestoKb;
   }
 
   convertGbToMb(gb: number) {

--- a/src/services/windows-files.service.ts
+++ b/src/services/windows-files.service.ts
@@ -19,7 +19,7 @@ export class WindowsFilesService extends FileService {
         if (err) {
           throw err;
         }
-        observer.next(super.convertBToKb(size));
+        observer.next(super.convertBytesToKb(size));
         observer.complete();
       });
     });


### PR DESCRIPTION
- Replace `convertBToKb` with `convertBytesToKb` for clarity #26 
- Fix typos in `README` and `CONTRIBUTING`
- Fix spacing in `--help` output
![image](https://user-images.githubusercontent.com/8295888/67634352-a66c7800-f8e0-11e9-8c7e-d27b68a50626.png)
