### PR TITLE
Fix du parameters on macOS

### DIFF
--- a/src/services/linux-files.service.ts
+++ b/src/services/linux-files.service.ts
@@ -11,14 +11,14 @@ export class LinuxFilesService extends FileService {
   }
 
   getFolderSize(path: string): Observable<{}> {
-    const du = spawn('du', ['-s', '-b', path]);
+    const du = spawn('du', ['-sk', path]);
     const cut = spawn('cut', ['-f', '1']);
 
     du.stdout.pipe(cut.stdin);
 
     return this.streamService
       .getStream(cut)
-      .pipe(map(size => super.convertBytesToKB(+size)));
+      .pipe(map(size => +size));
   }
 
   listDir(params: IListDirParams): Observable<Buffer> {


### PR DESCRIPTION
Fixes #70 by not using the unsupported `-b` flag on macOS. Instead, we use `-k` which is supported on both Linux and macOS. Since the reported value is already in kilobytes, we no longer have to convert it in npkill.

Also fixes #67 (same issue).