### PR TITLE
[Fix] 'win32' platform (running on Node <12.10.0) - Callback is not a function error

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -4,3 +4,4 @@ export * from './messages.constants';
 export * from './sort.result';
 export * from './spinner.constants';
 export * from './update.constants';
+export * from './recursive-rmdir-node-support.constants';

--- a/src/constants/recursive-rmdir-node-support.constants.ts
+++ b/src/constants/recursive-rmdir-node-support.constants.ts
@@ -4,3 +4,5 @@ export const RECURSIVE_RMDIR_NODE_VERSION_SUPPORT: Pick<INodeVersion, 'major' | 
   major: 12,
   minor: 10
 };
+
+export const RECURSIVE_RMDIR_IGNORED_ERROR_CODES: string[] = ['ENOTEMPTY', 'EEXIST'];

--- a/src/constants/recursive-rmdir-node-support.constants.ts
+++ b/src/constants/recursive-rmdir-node-support.constants.ts
@@ -1,0 +1,6 @@
+import { INodeVersion } from '@interfaces/node-version.interface'
+
+export const RECURSIVE_RMDIR_NODE_VERSION_SUPPORT: Pick<INodeVersion, 'major' | 'minor'> = {
+  major: 12,
+  minor: 10
+};

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -137,7 +137,7 @@ export class Controller {
     if (options['target-folder'])
       this.config.targetFolder = options['target-folder'];
     if (options['bg-color']) this.setColor(options['bg-color']);
-    
+
     // Remove trailing slash from folderRoot for consistency
     this.folderRoot = this.folderRoot.replace(/[\/\\]$/, '');
   }
@@ -478,7 +478,7 @@ export class Controller {
     const command = this.getCommand(name);
     if (command) this.KEYS.execute(name);
 
-    this.printFoldersSection();
+    if (name !== 'space') this.printFoldersSection();
   }
 
   private setErrorEvents(): void {
@@ -660,6 +660,7 @@ export class Controller {
     }
 
     folder.status = 'deleting';
+    this.printFoldersSection();
 
     this.fileService
       .deleteDir(folder.path)

--- a/src/interfaces/error-callback.interface.ts
+++ b/src/interfaces/error-callback.interface.ts
@@ -1,0 +1,3 @@
+import ErrnoException = NodeJS.ErrnoException;
+
+export type IErrorCallback = (err?: ErrnoException) => void;

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -9,3 +9,4 @@ export * from './stats.interface';
 export * from './ui-positions.interface';
 export * from './version.interface';
 export * from './node-version.interface';
+export * from './error-callback.interface';

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -8,3 +8,4 @@ export * from './list-dir-params.interface';
 export * from './stats.interface';
 export * from './ui-positions.interface';
 export * from './version.interface';
+export * from './node-version.interface';

--- a/src/interfaces/node-version.interface.ts
+++ b/src/interfaces/node-version.interface.ts
@@ -1,0 +1,5 @@
+export interface INodeVersion {
+  major: number;
+  minor: number;
+  patch: number;
+}

--- a/src/services/windows-files.service.ts
+++ b/src/services/windows-files.service.ts
@@ -1,12 +1,12 @@
 import { normalize, join as pathJoin } from 'path';
-import { rmdir, existsSync, readdirSync, lstatSync, unlinkSync, rmdirSync } from 'fs';
+import { rmdir, lstat, unlink, readdir } from 'fs';
 import { version } from 'process';
 
 import * as getSize from 'get-folder-size';
 
 import { FileService, StreamService } from '@core/services';
-import { INodeVersion } from '@core/interfaces';
-import { RECURSIVE_RMDIR_NODE_VERSION_SUPPORT } from '@core/constants';
+import { IErrorCallback, INodeVersion } from '@core/interfaces';
+import { RECURSIVE_RMDIR_IGNORED_ERROR_CODES, RECURSIVE_RMDIR_NODE_VERSION_SUPPORT } from '@core/constants';
 
 import { IListDirParams } from '@core/interfaces/list-dir-params.interface';
 import { Observable } from 'rxjs';
@@ -52,20 +52,20 @@ export class WindowsFilesService extends FileService {
       const { major: currentMajor, minor: currentMinor } = this.nodeVersion;
 
       if (currentMajor < supportedMajor || (currentMajor === supportedMajor && currentMinor < supportedMinor)) {
-        try {
-          this.removeDirectorySynchronously(path)
-          return resolve(true);
-        } catch (err) {
-          return reject(err);
-        }
+        this.removeRecursively(path, err => {
+          if (err) {
+            return reject(err);
+          }
+          resolve(true);
+        });
+      } else {
+        rmdir(path, { recursive: true }, err => {
+          if (err) {
+            reject(err);
+          }
+          resolve(true);
+        });
       }
-
-      rmdir(path, { recursive: true }, err => {
-        if (err) {
-          reject(err);
-        }
-        resolve(true);
-      });
     });
   }
 
@@ -84,21 +84,80 @@ export class WindowsFilesService extends FileService {
     };
   }
 
-  protected removeDirectorySynchronously(dirPath: string): void {
-    if (existsSync(dirPath)) {
-      const ls = readdirSync(dirPath);
+  protected removeRecursively(dirOrFilePath: string, callback: IErrorCallback): void {
+    lstat(dirOrFilePath, (lstatError, stats) => {
+      //  No such file or directory - Done
+      if (lstatError && lstatError.code === 'ENOENT') {
+        return callback(null);
+      }
+
+      if(stats.isDirectory()) {
+        return this.removeDirectory(dirOrFilePath, callback);
+      }
+
+      unlink(dirOrFilePath, rmError => {
+        //  No such file or directory - Done
+        if (rmError && rmError.code === 'ENOENT') {
+          return callback(null);
+        }
+
+        if (rmError && rmError.code === 'EISDIR') {
+          return this.removeDirectory(dirOrFilePath, callback);
+        }
+
+        callback(rmError);
+      });
+    });
+  }
+
+  protected removeDirectory(path: string, callback) {
+    rmdir(path, rmDirError => {
+      //  We ignore certain error codes
+      //  in order to simulate 'recursive' mode
+      if (rmDirError && RECURSIVE_RMDIR_IGNORED_ERROR_CODES.includes(rmDirError.code)) {
+        return this.removeChildren(path, callback);
+      }
+
+      callback(rmDirError);
+    });
+  }
+
+  protected removeChildren(path: string, callback) {
+    readdir(path, (readdirError, ls) => {
+      if (readdirError) {
+        return callback(readdirError);
+      }
+
+      let contentInDirectory = ls.length;
+      let done = false;
+
+      //  removeDirectory only allows deleting directories
+      //  that has no content inside (empty directory).
+      if (!contentInDirectory) {
+        return rmdir(path, callback);
+      }
 
       ls.forEach(dirOrFile => {
-        const dirOrFilePath = pathJoin(dirPath, dirOrFile);
+        const dirOrFilePath = pathJoin(path, dirOrFile);
 
-        if (lstatSync(dirOrFilePath).isDirectory()) {
-          this.removeDirectorySynchronously(dirOrFilePath);
-        } else {
-          unlinkSync(dirOrFilePath);
-        }
+        this.removeRecursively(dirOrFilePath, error => {
+          if (done) {
+            return;
+          }
+
+          if (error) {
+            done = true;
+            return callback(error);
+          }
+
+          contentInDirectory--;
+          //  No more content inside.
+          //  Remove the directory.
+          if (!contentInDirectory) {
+            rmdir(path, callback);
+          }
+        });
       });
-
-      rmdirSync(dirPath);
-    }
+    });
   }
 }

--- a/src/services/windows-files.service.ts
+++ b/src/services/windows-files.service.ts
@@ -1,8 +1,12 @@
-import { normalize } from 'path';
-import { rmdir } from 'fs';
+import { normalize, join as pathJoin } from 'path';
+import { rmdir, existsSync, readdirSync, lstatSync, unlinkSync, rmdirSync } from 'fs';
+import { version } from 'process';
+
 import * as getSize from 'get-folder-size';
 
 import { FileService, StreamService } from '@core/services';
+import { INodeVersion } from '@core/interfaces';
+import { RECURSIVE_RMDIR_NODE_VERSION_SUPPORT } from '@core/constants';
 
 import { IListDirParams } from '@core/interfaces/list-dir-params.interface';
 import { Observable } from 'rxjs';
@@ -39,6 +43,23 @@ export class WindowsFilesService extends FileService {
 
   deleteDir(path: string): Promise<boolean> {
     return new Promise((resolve, reject) => {
+      const { major: supportedMajor, minor: supportedMinor } = RECURSIVE_RMDIR_NODE_VERSION_SUPPORT;
+
+      if (this.nodeVersion instanceof Error) {
+        return reject(this.nodeVersion);
+      }
+
+      const { major: currentMajor, minor: currentMinor } = this.nodeVersion;
+
+      if (currentMajor < supportedMajor || (currentMajor === supportedMajor && currentMinor < supportedMinor)) {
+        try {
+          this.removeDirectorySynchronously(path)
+          return resolve(true);
+        } catch (err) {
+          return reject(err);
+        }
+      }
+
       rmdir(path, { recursive: true }, err => {
         if (err) {
           reject(err);
@@ -46,5 +67,38 @@ export class WindowsFilesService extends FileService {
         resolve(true);
       });
     });
+  }
+
+  protected get nodeVersion(): INodeVersion | Error {
+    const releaseVersionsRegExp: RegExp = /^v(\d{1,2})\.(\d{1,2})\.(\d{1,2})/;
+    const versionMatch = version.match(releaseVersionsRegExp);
+
+    if (!versionMatch) {
+      return new Error(`Unable to parse Node version: ${version}`);
+    }
+
+    return {
+      major: parseInt(versionMatch[1], 10),
+      minor: parseInt(versionMatch[2], 10),
+      patch: parseInt(versionMatch[3], 10),
+    };
+  }
+
+  protected removeDirectorySynchronously(dirPath: string): void {
+    if (existsSync(dirPath)) {
+      const ls = readdirSync(dirPath);
+
+      ls.forEach(dirOrFile => {
+        const dirOrFilePath = pathJoin(dirPath, dirOrFile);
+
+        if (lstatSync(dirOrFilePath).isDirectory()) {
+          this.removeDirectorySynchronously(dirOrFilePath);
+        } else {
+          unlinkSync(dirOrFilePath);
+        }
+      });
+
+      rmdirSync(dirPath);
+    }
   }
 }


### PR DESCRIPTION
✅ Closes: #5492 

# ↪️ Pull Request

Addresses the runtime error `Callback is not a function error` on *win32* platform running on `Node` versions *< 12.10.0*.

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (as case there aren't any unit tests)
- [x] Included links to related issues/PRs

## 📝 Additional notes

After the change I ensured that:
 * all tests are passing, by running `npm run test`,
 * no stylistic or unwanted errors are present,
 * formating is consistent.

## 🚨 Manual test instructions

Running the local build of `npkill` tool with the code from the source branch with the included changes in a directory that includes (several) `node_module` (a few directories deep) successfully removes directories with no errors thrown during runtime. The removal is also *asynchronous* which follows the `npkill` convetion.
This change only affects the `win32` platform running `Node` version < 12.10.0.
*No other platforms / Node versions are affected* by this change.

## Additional context of the change (and the bug itself)

I was able to reproduce the issue on `posix` platform by having the `deleteDir` method from `WindowsFilesService` copied over to an appropriate class that extends `UnixFilesService` (based on my OS). In order to get the error thrown during the runtime I had to downgrade my `Node` version to < 12.10.0.

**Why?** The `fs.rmdir` API had a **major change** on the version 12.10.0 (although NOT a breaking change since the new method version is backwards compatible) that allowed the method to support *options* argument.
`v12.10.0 - The recursive, maxBusyTries, and emfileWait options are now supported.`

As taken from the method's typings files the `fs.rmdir` method accepts up to 3 arguments on `Node` versions >= 12.10.0:
```
function rmdir(path: PathLike, callback: NoParamCallback): void;
function rmdir(path: PathLike, options: RmDirOptions, callback: NoParamCallback): void;
```

Prior to `Node` release 12.10.0 `fs.rmdir` method supported only 2 arguments and both of them needed to be provided (some, even older versions of `Node` marked callback parameter as option).
Also, second argument needed to be of type `function`.
```
function rmdir(path: PathLike, callback: NoParamCallback): void;
```

I didn't want to depend on `fs.promises` nor `util.promisify` APIs as that would limit the number of `Node` version supported.
I didn't test the code on versions below `v10.15.3` as per [official releases document found on Nodejs website](https://nodejs.org/en/about/releases/) version `10` is the least supported version of Node with a support ending on Apr 2021 (a few months from the time of writing this).

However, as per current implementation `Node` versions supported are drastically increased since the methods used date to the first very few **production** versions of Node (that I assume people are still running from legacy reasons).

I might be able to supply some unit tests, however I need to *stub* most of the method logic which *imho* might defeat the purpose of the unit test, however I will try to make a commit that will add some sort of unit tests.