### PR TITLE
Show warning with system applications node_modules

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -78,6 +78,8 @@ You can also use <kbd>j</kbd> and <kbd>k</kbd> to move between the results
 
 To exit, <kbd>Q</kbd> or <kbd>Ctrl</kbd> + <kbd>c</kbd> if you're brave.
 
+**Important!** Some applications installed on the system need their node_modules directory to work and deleting them may break them. NPKILL will highlight them by displaying a :warning: to be careful.
+
 <a name="options"></a>
 
 ## Options

--- a/src/constants/cli.constants.ts
+++ b/src/constants/cli.constants.ts
@@ -69,6 +69,9 @@ export const OPTIONS: ICliOptions[] = [
   },
 ];
 
+export const HELP_WARNING =
+  'Not all node_modules are bad! Some applications (like vscode, Discord, etc) need those dependencies to work. If their directory is deleted, the application will probably break (until the dependencies are reinstalled). NPKILL will show you these directories by highlighting them ⚠️';
+
 export const COLORS = {
   cyan: 'bgCyan',
   magenta: 'bgMagenta',

--- a/src/constants/main.constants.ts
+++ b/src/constants/main.constants.ts
@@ -9,6 +9,7 @@ export const OVERFLOW_CUT_FROM = 8;
 
 export const DEFAULT_CONFIG: IConfig = {
   backgroundColor: 'bgBlue',
+  warningColor: 'brightYellow',
   checkUpdates: true,
   deleteAll: false,
   exclude: [],

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -347,6 +347,9 @@ export class Controller {
       this.paintBgRow(row);
     }
 
+    if (folder.isDangerous)
+      path = colors[DEFAULT_CONFIG.warningColor](path + '⚠️');
+
     this.printAt(path, {
       x: MARGINS.FOLDER_COLUMN_START,
       y: row,

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -518,7 +518,12 @@ export class Controller {
           from(this.consoleService.splitData(dataFolder.toString())),
         ),
         filter((path) => !!path),
-        map<string, IFolder>((path) => ({ path, size: 0, status: 'live' })),
+        map<string, IFolder>((path) => ({
+          path,
+          size: 0,
+          isDangerous: this.fileService.isDangerous(path),
+          status: 'live',
+        })),
         tap((nodeFolder) => {
           this.resultsService.addResult(nodeFolder);
 

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -13,7 +13,7 @@ import {
   UI_POSITIONS,
   VALID_KEYS,
 } from '@core/constants/main.constants';
-import { COLORS, OPTIONS } from '@core/constants/cli.constants';
+import { COLORS, HELP_WARNING, OPTIONS } from '@core/constants/cli.constants';
 import {
   ConsoleService,
   FileService,
@@ -169,7 +169,7 @@ export class Controller {
       });
     });
 
-    this.printAt('', {
+    this.printAt(HELP_WARNING, {
       x: 0,
       y: lineCount * 2 + 2,
     });

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -339,8 +339,9 @@ export class Controller {
 
   private printFolderRow(folder: IFolder, row: number) {
     let { path, size } = this.getFolderTexts(folder);
+    const isRowSelected = row === this.getRealCursorPosY();
 
-    if (row === this.getRealCursorPosY()) {
+    if (isRowSelected) {
       path = colors[this.config.backgroundColor](path);
       size = colors[this.config.backgroundColor](size);
       this.paintBgRow(row);

--- a/src/interfaces/config.interface.ts
+++ b/src/interfaces/config.interface.ts
@@ -1,5 +1,6 @@
 export interface IConfig {
   backgroundColor: string;
+  warningColor: string;
   checkUpdates: boolean;
   deleteAll: boolean;
   folderSizeInGB: boolean;

--- a/src/interfaces/file-service.interface.ts
+++ b/src/interfaces/file-service.interface.ts
@@ -10,4 +10,5 @@ export interface IFileService {
   convertGBToMB(gb: number): number;
   getFileContent(path: string): string;
   isSafeToDelete(path: string, targetFolder: string): boolean;
+  isDangerous(path: string): boolean;
 }

--- a/src/interfaces/folder.interface.ts
+++ b/src/interfaces/folder.interface.ts
@@ -1,6 +1,7 @@
 export interface IFolder {
   path: string;
   size: number;
+  isDangerous: boolean;
   status: 'live' | 'deleting' | 'error-deleting' | 'deleted';
 }
 

--- a/src/services/files.service.ts
+++ b/src/services/files.service.ts
@@ -32,4 +32,9 @@ export abstract class FileService implements IFileService {
   isSafeToDelete(path: string, targetFolder: string): boolean {
     return path.includes(targetFolder);
   }
+
+  isDangerous(path: string): boolean {
+    const hiddenFilePattern = /(^|\/)\.[^\/\.]/g;
+    return hiddenFilePattern.test(path);
+  }
 }

--- a/src/services/files.service.ts
+++ b/src/services/files.service.ts
@@ -34,6 +34,13 @@ export abstract class FileService implements IFileService {
   }
 
   isDangerous(path: string): boolean {
+    /* We consider a directory to be dangerous if it is hidden.
+     
+      > Why dangerous?
+      It is probable that if the node_module is included in some hidden directory, it is
+      required by some application like "spotify", "vscode" or "Discord" and deleting it
+      would imply breaking the application (until the dependencies are reinstalled).
+    */
     const hiddenFilePattern = /(^|\/)\.[^\/\.]/g;
     return hiddenFilePattern.test(path);
   }


### PR DESCRIPTION
## This feature highlights results that are in hidden folders in unix to avoid deleting them by mistake.

Some applications need their dependencies to work, so deleting them would break them (until they are reinstalled).
A few users have reported deleting them by accident.
These node_modules are usually found in hidden directories (such as /home/user/.vscode/[...]), so a :warning: will now be displayed to better identify those results that we probably don't want to... _'pluff'_.

#### Preview
![image](https://user-images.githubusercontent.com/16844185/113463091-4a3a4b80-9424-11eb-9932-b8c4693c16c8.png)
