### PR TITLE
Fix: wrong results and wrong releasable space

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -47,6 +47,7 @@ import {
 
 import { FOLDER_SORT } from './constants/sort.result';
 import ansiEscapes from 'ansi-escapes';
+import { bufferObserve } from './libs/buffer-observer';
 
 export class Controller {
   private folderRoot = '';
@@ -500,21 +501,23 @@ export class Controller {
 
   private scan(): void {
     const params: IListDirParams = this.prepareListDirParams();
-
+    const bufferFilter = (text: string) =>
+      text.endsWith(this.config.targetFolder + '\n');
     const folders$ = this.fileService.listDir(params);
+
     folders$
       .pipe(
         catchError((error, caught) => {
           if (error.bash) {
             this.printFolderError(error.message);
-
             return caught;
           }
-
           throw error;
         }),
+        map((buffer) => buffer.toString()),
+        bufferObserve((dataFolder) => bufferFilter(dataFolder)),
         mergeMap((dataFolder) =>
-          from(this.consoleService.splitData(dataFolder.toString())),
+          from(this.consoleService.splitData(dataFolder)),
         ),
         filter((path) => !!path),
         map<string, IFolder>((path) => ({ path, size: 0, status: 'live' })),

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -501,8 +501,8 @@ export class Controller {
 
   private scan(): void {
     const params: IListDirParams = this.prepareListDirParams();
-    const bufferFilter = (text: string) =>
-      text.endsWith(this.config.targetFolder + '\n');
+    const isChunkCompleted = (chunk: string) =>
+      chunk.endsWith(this.config.targetFolder + '\n');
     const folders$ = this.fileService.listDir(params);
 
     folders$
@@ -515,7 +515,7 @@ export class Controller {
           throw error;
         }),
         map((buffer) => buffer.toString()),
-        bufferUntil((chunk) => bufferFilter(chunk)),
+        bufferUntil((chunk) => isChunkCompleted(chunk)),
         mergeMap((dataFolder) =>
           from(this.consoleService.splitData(dataFolder)),
         ),

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -47,7 +47,7 @@ import {
 
 import { FOLDER_SORT } from './constants/sort.result';
 import ansiEscapes from 'ansi-escapes';
-import { bufferObserve } from './libs/buffer-observer';
+import { bufferUntil } from './libs/buffer-until';
 
 export class Controller {
   private folderRoot = '';
@@ -515,7 +515,7 @@ export class Controller {
           throw error;
         }),
         map((buffer) => buffer.toString()),
-        bufferObserve((dataFolder) => bufferFilter(dataFolder)),
+        bufferUntil((chunk) => bufferFilter(chunk)),
         mergeMap((dataFolder) =>
           from(this.consoleService.splitData(dataFolder)),
         ),

--- a/src/libs/buffer-observer.ts
+++ b/src/libs/buffer-observer.ts
@@ -1,0 +1,40 @@
+import { OperatorFunction, Observable, of } from 'rxjs';
+
+class Buffer<T> {
+  values = '';
+
+  append(value: string) {
+    this.values += value;
+  }
+
+  reset() {
+    this.values = '';
+  }
+}
+
+export function bufferObserve<T>(
+  filter: (buffer: string) => boolean,
+  resetNotifier: Observable<any> = of(),
+): OperatorFunction<string, string> {
+  return function (source$: Observable<string>): Observable<string> {
+    let buffer = new Buffer<T>();
+
+    return new Observable((observer) => {
+      const resetNotifierSubscription = resetNotifier.subscribe(() =>
+        buffer.reset(),
+      );
+      source$.subscribe({
+        next: (value: string) => {
+          buffer.append(value);
+
+          if (filter(buffer.values)) {
+            observer.next(buffer.values);
+            buffer.reset();
+          }
+        },
+        error: () => resetNotifierSubscription.unsubscribe(),
+        complete: () => resetNotifierSubscription.unsubscribe(),
+      });
+    });
+  };
+}

--- a/src/libs/buffer-until.ts
+++ b/src/libs/buffer-until.ts
@@ -12,7 +12,7 @@ class Buffer<T> {
   }
 }
 
-export function bufferObserve<T>(
+export function bufferUntil<T>(
   filter: (buffer: string) => boolean,
   resetNotifier: Observable<any> = of(),
 ): OperatorFunction<string, string> {


### PR DESCRIPTION
These changes are responsible for checking that the results of the directory scan are complete.
This is necessary because the analysis command generates chunks of data, and could eventually fragment them, causing wrong results (more info: https://github.com/voidcosmos/npkill/issues/40#issuecomment-812891661)

This fix #40 , fix #78 and resolve #28