### PR TITLE
refactor(windows-files.service): update deprecated rmdir function

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@stryker-mutator/jest-runner": "^3.1.0",
     "@stryker-mutator/typescript": "^3.1.0",
     "@types/jest": "^25.1.4",
-    "@types/node": "^13.9.8",
+    "@types/node": "^15.12.4",
     "@types/colors": "^1.2.1",
     "commitlint": "^8.3.5",
     "del": "^5.1.0",

--- a/src/services/windows-files.service.ts
+++ b/src/services/windows-files.service.ts
@@ -1,5 +1,5 @@
 import { normalize, join as pathJoin } from 'path';
-import { rmdir, lstat, unlink, readdir } from 'fs';
+import { rm, lstat, unlink, readdir } from 'fs';
 import { version } from 'process';
 
 import * as getSize from 'get-folder-size';
@@ -59,7 +59,7 @@ export class WindowsFilesService extends FileService {
           resolve(true);
         });
       } else {
-        rmdir(path, { recursive: true }, err => {
+        rm(path, { recursive: true }, err => {
           if (err) {
             reject(err);
           }
@@ -111,7 +111,7 @@ export class WindowsFilesService extends FileService {
   }
 
   protected removeDirectory(path: string, callback) {
-    rmdir(path, rmDirError => {
+    rm(path, rmDirError => {
       //  We ignore certain error codes
       //  in order to simulate 'recursive' mode
       if (rmDirError && RECURSIVE_RMDIR_IGNORED_ERROR_CODES.includes(rmDirError.code)) {
@@ -134,7 +134,7 @@ export class WindowsFilesService extends FileService {
       //  removeDirectory only allows deleting directories
       //  that has no content inside (empty directory).
       if (!contentInDirectory) {
-        return rmdir(path, callback);
+        return rm(path, callback);
       }
 
       ls.forEach(dirOrFile => {
@@ -154,7 +154,7 @@ export class WindowsFilesService extends FileService {
           //  No more content inside.
           //  Remove the directory.
           if (!contentInDirectory) {
-            rmdir(path, callback);
+            rm(path, callback);
           }
         });
       });


### PR DESCRIPTION
The fs.rmdir function is deprecated in Node 16, so changed all to fs.rm as Node recommended

![image](https://user-images.githubusercontent.com/43035480/123102962-248f7200-d468-11eb-90a1-c9372924712f.png)
