### PR TITLE
index.ts nit

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,9 +3,8 @@
 const tsConfig = require('./tsconfig.build.json');
 const tsConfigPaths = require('tsconfig-paths');
 
-const baseUrl = __dirname;
-const cleanup = tsConfigPaths.register({
-  baseUrl,
+tsConfigPaths.register({
+  baseUrl: __dirname,
   paths: tsConfig.compilerOptions.paths,
 });
 


### PR DESCRIPTION
`index.ts` seems to be based on https://github.com/dividab/tsconfig-paths#bootstrapping-with-explicit-params 

`cleanup` is currently unused 