### PR TITLE
feat: add option to exclude hidden directories from search

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -97,6 +97,7 @@ To exit, <kbd>Q</kbd> or <kbd>Ctrl</kbd> + <kbd>c</kbd> if you're brave.
 | -nu, --no-check-update | Don't check for updates on startup                                                                                                             |
 | -s, --sort             | Sort results by: size or path _[ beta ]_                                                                                                       |
 | -t, --target           | Specify the name of the directories you want to search (by default, is node_modules)                                                           |
+| -x, --exclude-hidden-directories | Exclude hidden directories ("dot" directories) from search.                                                                          |
 | -v, --version          | Show npkill version                                                                                                                            |
 
 **Warning:** _In future versions some commands may change_

--- a/README.MD
+++ b/README.MD
@@ -84,21 +84,21 @@ To exit, <kbd>Q</kbd> or <kbd>Ctrl</kbd> + <kbd>c</kbd> if you're brave.
 
 ## Options
 
-| ARGUMENT               | DESCRIPTION                                                                                                                                    |
-| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| -c, --bg-color         | Change row highlight color. _(Available: **blue**, cyan, magenta, white, red and yellow)_                                                      |
-| -d, --directory        | Set the directory from which to begin searching. By default, starting-point is .                                                               |
-| -D, --delete-all       | CURRENTLY DISABLED. Automatically delete all node_modules folders that are found                                                               |
-| -e, --show-errors      | Show error messages related to the search if any                                                                                               |
-| -E, --exclude          | Exclude directories from search (directory list must be inside double quotes "", each directory separated by ',' ) Example: "ignore1, ignore2" |
-| -f, --full             | Start searching from the home of the user (example: "/home/user" in linux)                                                                     |
-| -gb                    | Show folders in Gigabytes instead of Megabytes.                                                                                                |
-| -h, --help, ?          | Show this help page and exit                                                                                                                   |
-| -nu, --no-check-update | Don't check for updates on startup                                                                                                             |
-| -s, --sort             | Sort results by: size or path _[ beta ]_                                                                                                       |
-| -t, --target           | Specify the name of the directories you want to search (by default, is node_modules)                                                           |
-| -x, --exclude-hidden-directories | Exclude hidden directories ("dot" directories) from search.                                                                          |
-| -v, --version          | Show npkill version                                                                                                                            |
+| ARGUMENT                         | DESCRIPTION                                                                                                                                    |
+| ----------------------           | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| -c, --bg-color                   | Change row highlight color. _(Available: **blue**, cyan, magenta, white, red and yellow)_                                                      |
+| -d, --directory                  | Set the directory from which to begin searching. By default, starting-point is .                                                               |
+| -D, --delete-all                 | CURRENTLY DISABLED. Automatically delete all node_modules folders that are found                                                               |
+| -e, --show-errors                | Show error messages related to the search if any                                                                                               |
+| -E, --exclude                    | Exclude directories from search (directory list must be inside double quotes "", each directory separated by ',' ) Example: "ignore1, ignore2" |
+| -f, --full                       | Start searching from the home of the user (example: "/home/user" in linux)                                                                     |
+| -gb                              | Show folders in Gigabytes instead of Megabytes.                                                                                                |
+| -h, --help, ?                    | Show this help page and exit                                                                                                                   |
+| -nu, --no-check-update           | Don't check for updates on startup                                                                                                             |
+| -s, --sort                       | Sort results by: size or path _[ beta ]_                                                                                                       |
+| -t, --target                     | Specify the name of the directories you want to search (by default, is node_modules)                                                           |
+| -x, --exclude-hidden-directories | Exclude hidden directories ("dot" directories) from search.                                                                                    |
+| -v, --version                    | Show npkill version                                                                                                                            |
 
 **Warning:** _In future versions some commands may change_
 

--- a/__tests__/console.service.test.ts
+++ b/__tests__/console.service.test.ts
@@ -18,6 +18,7 @@ describe('Console Service', () => {
         'lala',
         'random text',
         '-f',
+        '--exclude-hidden-directories',
       ];
 
       const result = consoleService.getParameters(argvs);
@@ -28,6 +29,7 @@ describe('Console Service', () => {
       expect(result['lala']).toBeUndefined();
       expect(result['inexistent']).toBeUndefined();
       expect(result['full-scan']).not.toBeFalsy();
+      expect(result['exclude-hidden-directories']).not.toBeFalsy();
     });
     it('should get valid parameters 2', () => {
       const argvs = [
@@ -44,6 +46,7 @@ describe('Console Service', () => {
       expect(result['help']).toBeFalsy();
       expect(result['full-scan']).not.toBeFalsy();
       expect(result['bg-color']).toBe('red');
+      expect(result['exclude-hidden-directories']).toBeFalsy();
     });
   });
 

--- a/src/constants/cli.constants.ts
+++ b/src/constants/cli.constants.ts
@@ -63,6 +63,11 @@ export const OPTIONS: ICliOptions[] = [
     name: 'target-folder',
   },
   {
+    arg: ['-x', '--exclude-hidden-directories'],
+    description: 'Exclude hidden directories ("dot" directories) from search.',
+    name: 'exclude-hidden-directories',
+  },
+  {
     arg: ['-v', '--version'],
     description: 'Show version.',
     name: 'version',

--- a/src/constants/main.constants.ts
+++ b/src/constants/main.constants.ts
@@ -13,6 +13,7 @@ export const DEFAULT_CONFIG: IConfig = {
   checkUpdates: true,
   deleteAll: false,
   exclude: [],
+  excludeHiddenDirectories: false,
   folderSizeInGB: false,
   maxSimultaneousSearch: 6,
   showErrors: false,

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -521,6 +521,11 @@ export class Controller {
     const params: IListDirParams = this.prepareListDirParams();
     const isChunkCompleted = (chunk: string) =>
       chunk.endsWith(this.config.targetFolder + '\n');
+
+    const isExcludedDangerousDirectory = (path: string): boolean =>
+      this.config.excludeHiddenDirectories &&
+      this.fileService.isDangerous(path);
+
     const folders$ = this.fileService.listDir(params);
 
     folders$
@@ -538,6 +543,7 @@ export class Controller {
           from(this.consoleService.splitData(dataFolder)),
         ),
         filter((path) => !!path),
+        filter((path) => !isExcludedDangerousDirectory(path)),
         map<string, IFolder>((path) => ({
           path,
           size: 0,

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -149,6 +149,8 @@ export class Controller {
     if (options['target-folder'])
       this.config.targetFolder = options['target-folder'];
     if (options['bg-color']) this.setColor(options['bg-color']);
+    if (options['exclude-hidden-directories'])
+      this.config.excludeHiddenDirectories = true;
 
     // Remove trailing slash from folderRoot for consistency
     this.folderRoot = this.folderRoot.replace(/[\/\\]$/, '');

--- a/src/interfaces/config.interface.ts
+++ b/src/interfaces/config.interface.ts
@@ -9,4 +9,5 @@ export interface IConfig {
   sortBy: string;
   targetFolder: string;
   exclude: string[];
+  excludeHiddenDirectories: boolean;
 }


### PR DESCRIPTION
This PR closes #105 . It filters out hidden (dangerous) directories from the search results when the "-x" or "--exclude-hidden-directories" option is passed.

The implementation uses the `isDangerous` method to check for hidden directories, as suggested in the issue's discussion.

I couldn't find any tests for the `scan()` method, so I didn't add any tests. Please tell if that is needed.