### PR TITLE
fix(help-ui): help command does not print all the result in the large window

### DIFF
--- a/src/ui/components/help.ui.ts
+++ b/src/ui/components/help.ui.ts
@@ -50,10 +50,7 @@ export class HelpUi extends BaseUi {
       });
     });
 
-    this.printAt(HELP_FOOTER + '\n', {
-      x: 0,
-      y: lineCount * 2 + 2,
-    });
+    this.print(HELP_FOOTER + '\n');
   }
 
   clear(): void {


### PR DESCRIPTION
The bug can be reproduced when the `this.terminal.rows` is more than `lineCount * 2 + 2`. Honestly, I failed to understand why it can happen, but replacing the last message with `this.print` will help.

**Before**

https://user-images.githubusercontent.com/37064641/232635473-ba1386ee-16b2-4ca4-b4c8-58232ec937b7.mp4

**After**

https://user-images.githubusercontent.com/37064641/232635633-d6cd7d13-1f1f-4359-a416-d6a7177662f8.mp4



