### PR TITLE
feat: enable deleting with "DELete" in addition to "SPACE"

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ $ npx npkill
 
 By default, npkill will scan for node_modules starting at the path where `npkill` command is executed.
 
-Move between the listed folders with <kbd>↓</kbd> <kbd>↑</kbd>, and use <kbd>Space</kbd> to delete the selected folder.
+Move between the listed folders with <kbd>↓</kbd> <kbd>↑</kbd>, and use <kbd>Space</kbd> or <kbd>Del</kbd> to delete the selected folder.
 You can also use <kbd>j</kbd> and <kbd>k</kbd> to move between the results
 
 To exit, <kbd>Q</kbd> or <kbd>Ctrl</kbd> + <kbd>c</kbd> if you're brave.

--- a/src/constants/cli.constants.ts
+++ b/src/constants/cli.constants.ts
@@ -78,7 +78,7 @@ export const OPTIONS: ICliOptions[] = [
 
 export const HELP_HEADER = `This tool allows you to list any node_modules directories in your system, as well as the space they take up. You can then select which ones you want to erase to free up space.
  ┌------ CONTROLS --------------------
- 🭲 SPACE:                 delete selected result
+ 🭲 SPACE, DEL:            delete selected result
  🭲 Cursor UP, k:          move up
  🭲 Cursor DOWN, j:        move down
  🭲 h, d, Ctrl+d, PgUp:    move one page down

--- a/src/ui/components/results.ui.ts
+++ b/src/ui/components/results.ui.ts
@@ -32,6 +32,7 @@ export class ResultsUi extends HeavyUi implements InteractiveUi {
     up: () => this.cursorUp(),
     down: () => this.cursorDown(),
     space: () => this.delete(),
+    delete: () => this.delete(),
     j: () => this.cursorDown(),
     k: () => this.cursorUp(),
     h: () => this.cursorPageDown(),


### PR DESCRIPTION
While working with npkil I found it more natural to delete by using the DEL key (muscle memory) than using the the space key. As it is only a one line change I think it will not hurt to support also the DEL key for persons with the same muscle memory.