### PR TITLE
fix: sort parameter for sorting by date

### DIFF
--- a/src/constants/cli.constants.ts
+++ b/src/constants/cli.constants.ts
@@ -59,7 +59,7 @@ export const OPTIONS: ICliOptions[] = [
   {
     arg: ['-s', '--sort'],
     description:
-      'Sort results by: size, path or date (last time the most recent file was modified in the workspace)',
+      'Sort results by: size, path or last-mod (last time the most recent file was modified in the workspace)',
     name: 'sort-by',
   },
   {


### PR DESCRIPTION
Thank you for this great tool! 😊

`npx npkill --sort date` says:

`Invalid sort option. Available: path | size | last-mod`

So I replace the text...