### PR TITLE
Improve isDangerous algorithm

### DIFF
--- a/__tests__/files.service.test.ts
+++ b/__tests__/files.service.test.ts
@@ -142,39 +142,112 @@ describe('File Service', () => {
     });
   });
 
-  describe('#isDangerous', () => {
-    it('should return false for paths that are not considered dangerous', () => {
-      expect(
-        fileService.isDangerous('/home/apps/myapp/node_modules'),
-      ).toBeFalsy();
-      expect(fileService.isDangerous('node_modules')).toBeFalsy();
-      expect(
-        fileService.isDangerous('/home/user/projects/a/node_modules'),
-      ).toBeFalsy();
-      expect(
-        fileService.isDangerous('/Applications/NotAnApp/node_modules'),
-      ).toBeFalsy();
-      expect(
-        fileService.isDangerous('C:\\Users\\User\\Documents\\node_modules'),
-      ).toBeFalsy();
+  describe('isDangerous', () => {
+    const originalEnv = { ...process.env };
+    const originalCwd = process.cwd();
+
+    const mockCwd = (cwd: string) => {
+      jest.spyOn(process, 'cwd').mockReturnValue(cwd);
+    };
+
+    afterAll(() => {
+      process.env = originalEnv;
     });
 
-    it('should return true for paths that are considered dangerous', () => {
-      expect(
-        fileService.isDangerous('/home/.config/myapp/node_modules'),
-      ).toBeTruthy();
-      expect(fileService.isDangerous('.apps/node_modules')).toBeTruthy();
-      expect(
-        fileService.isDangerous('.apps/.sample/node_modules'),
-      ).toBeTruthy();
-      expect(
-        fileService.isDangerous('/Applications/MyApp.app/node_modules'),
-      ).toBeTruthy();
-      expect(
-        fileService.isDangerous(
-          'C:\\Users\\User\\AppData\\Local\\node_modules',
-        ),
-      ).toBeTruthy();
+    describe('POSIX paths', () => {
+      beforeAll(() => {
+        process.env.HOME = '/home/user';
+        delete process.env.USERPROFILE;
+      });
+
+      test('safe relative path', () => {
+        mockCwd('/safe/path');
+        expect(fileService.isDangerous('../project/node_modules')).toBe(false);
+      });
+
+      test('hidden relative path', () => {
+        mockCwd('/home/user/projects');
+        expect(fileService.isDangerous('../.config/secret')).toBe(true);
+      });
+
+      test('node_modules in ~/.cache', () => {
+        expect(
+          fileService.isDangerous('/home/user/.cache/project/node_modules'),
+        ).toBe(false);
+      });
+
+      test('parent relative path (..)', () => {
+        mockCwd('/home/user');
+        expect(fileService.isDangerous('..')).toBe(false);
+      });
+
+      test('current relative path (.)', () => {
+        mockCwd('/home/user');
+        expect(fileService.isDangerous('.')).toBe(false);
+      });
+    });
+
+    describe('Windows paths', () => {
+      beforeAll(() => {
+        process.env.USERPROFILE = 'C:\\Users\\user';
+        process.env.HOME = '';
+      });
+
+      test('safe relative path', () => {
+        mockCwd('D:\\safe\\path');
+        expect(fileService.isDangerous('..\\project\\node_modules')).toBe(
+          false,
+        );
+      });
+
+      test('AppData relative path', () => {
+        mockCwd('C:\\Users\\user\\Documents');
+        expect(fileService.isDangerous('..\\AppData\\Roaming\\app')).toBe(true);
+      });
+
+      test('Program Files (x86)', () => {
+        expect(
+          fileService.isDangerous('C:\\Program Files (x86)\\app\\node_modules'),
+        ).toBe(true);
+      });
+
+      test('network paths', () => {
+        expect(
+          fileService.isDangerous('\\\\network\\share\\.hidden\\node_modules'),
+        ).toBe(true);
+      });
+    });
+
+    describe('Edge cases', () => {
+      test('no home directory', () => {
+        delete process.env.HOME;
+        delete process.env.USERPROFILE;
+        expect(fileService.isDangerous('/some/path')).toBe(false);
+      });
+
+      test('whitelisted hidden segments', () => {
+        expect(
+          fileService.isDangerous('/tmp/.cache/project/node_modules'),
+        ).toBe(false);
+        expect(fileService.isDangerous('/tmp/.npm/project/node_modules')).toBe(
+          false,
+        );
+      });
+
+      test('macOS application bundle', () => {
+        expect(
+          fileService.isDangerous(
+            '/Applications/MyApp.app/Contents/node_modules',
+          ),
+        ).toBe(true);
+      });
+
+      test('Windows-style path on POSIX', () => {
+        process.env.HOME = '/home/user';
+        expect(fileService.isDangerous('/home/user/AppData/Local/.cache')).toBe(
+          false,
+        );
+      });
     });
   });
 

--- a/src/services/files/files.service.ts
+++ b/src/services/files/files.service.ts
@@ -1,4 +1,5 @@
 import fs, { accessSync, readFileSync, Stats, statSync } from 'fs';
+import path from 'path';
 import {
   IFileService,
   IFileStat,
@@ -85,16 +86,64 @@ export abstract class FileService implements IFileService {
    * application-specific data or configurations that should not be tampered with. Deleting node_modules
    * from these locations could potentially disrupt the normal operation of these applications.
    */
-  isDangerous(path: string): boolean {
-    const hiddenFilePattern = /(^|\/)\.[^/.]/g;
-    const macAppsPattern = /(^|\/)Applications\/[^/]+\.app\//g;
-    const windowsAppDataPattern = /(^|\\)AppData\\/g;
+  isDangerous(originalPath: string): boolean {
+    const absolutePath = path.resolve(originalPath);
+    const normalizedPath = absolutePath.replace(/\\/g, '/').toLowerCase();
 
-    return (
-      hiddenFilePattern.test(path) ||
-      macAppsPattern.test(path) ||
-      windowsAppDataPattern.test(path)
+    const home = process.env.HOME || process.env.USERPROFILE || '';
+    let isInHome = false;
+
+    if (home) {
+      const normalizedHome = path
+        .resolve(home)
+        .replace(/\\/g, '/')
+        .toLowerCase();
+      isInHome = normalizedPath.startsWith(normalizedHome);
+    }
+
+    if (isInHome) {
+      if (/\/\.config(\/|$)/.test(normalizedPath)) {
+        return true;
+      }
+      if (/\/\.local\/share(\/|$)/.test(normalizedPath)) {
+        return true;
+      }
+      if (/\/\.(cache|npm|pnpm)(\/|$)/.test(normalizedPath)) {
+        return false;
+      }
+    }
+
+    if (/\/applications\/[^/]+\.app\//.test(normalizedPath)) {
+      return true;
+    }
+
+    if (normalizedPath.includes('/appdata/roaming')) {
+      return true;
+    }
+    if (normalizedPath.includes('/appdata/local')) {
+      if (/\/\.(cache|npm|pnpm)(\/|$)/.test(normalizedPath)) {
+        return false;
+      }
+      return true;
+    }
+    if (/program files( \(x86\))?\//.test(normalizedPath)) {
+      return true;
+    }
+
+    const segments = normalizedPath.split('/');
+    const hasUnsafeHiddenFolder = segments.some(
+      (segment) =>
+        segment.startsWith('.') &&
+        segment !== '.' &&
+        segment !== '..' &&
+        !['.cache', '.npm', '.pnpm'].includes(segment),
     );
+
+    if (hasUnsafeHiddenFolder) {
+      return true;
+    }
+
+    return false;
   }
 
   async getRecentModificationInDir(path: string): Promise<number> {


### PR DESCRIPTION
The patterns used so far was rather conservative and yielded "false positives". Of course, this is better than "false negatives".

The algorithm has been improved to not mark as ‘dangerous’ directories that would not have any dangerous consequences if deleted (like npm caches and so on).