### PR TITLE
Allow to define multiple directories targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,22 +98,23 @@ To exit, <kbd>Q</kbd> or <kbd>Ctrl</kbd> + <kbd>c</kbd> if you're brave.
 
 ## Options
 
-| ARGUMENT                         | DESCRIPTION                                                                                                                                    |
-| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| -c, --bg-color                   | Change row highlight color. _(Available: **blue**, cyan, magenta, white, red and yellow)_                                                      |
-| -d, --directory                  | Set the directory from which to begin searching. By default, starting-point is .                                                               |
-| -D, --delete-all                 | Automatically delete all node_modules folders that are found. Suggested to be used together with `-x`.                                         |
-| -e, --hide-errors                | Hide errors if any                                                                                                                             |
-| -E, --exclude                    | Exclude directories from search (directory list must be inside double quotes "", each directory separated by ',' ) Example: "ignore1, ignore2" |
-| -f, --full                       | Start searching from the home of the user (example: "/home/user" in linux)                                                                     |
-| -gb                              | Show folders in Gigabytes instead of Megabytes.                                                                                                |
-| -h, --help, ?                    | Show this help page and exit                                                                                                                   |
-| -nu, --no-check-update           | Don't check for updates on startup                                                                                                             |
-| -s, --sort                       | Sort results by: `size`, `path` or `last-mod`                                                                                                  |
-| -t, --target                     | Specify the name of the directories you want to search (by default, is node_modules)                                                           |
-| -x, --exclude-hidden-directories | Exclude hidden directories ("dot" directories) from search.                                                                                    |
-| --dry-run                        | It does not delete anything (will simulate it with a random delay).                                                                            |
-| -v, --version                    | Show npkill version                                                                                                                            |
+| ARGUMENT                         | DESCRIPTION                                                                                                                                                                         |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| -c, --bg-color                   | Change row highlight color. _(Available: **blue**, cyan, magenta, white, red and yellow)_                                                                                           |
+| -d, --directory                  | Set the directory from which to begin searching. By default, starting-point is .                                                                                                    |
+| -D, --delete-all                 | Automatically delete all node_modules folders that are found. Suggested to be used together with `-x`.                                                                              |
+| -e, --hide-errors                | Hide errors if any                                                                                                                                                                  |
+| -E, --exclude                    | Exclude directories from search (directory list must be inside double quotes "", each directory separated by ',' ) Example: "ignore1, ignore2"                                      |
+| -f, --full                       | Start searching from the home of the user (example: "/home/user" in linux)                                                                                                          |
+| -gb                              | Show folders in Gigabytes instead of Megabytes.                                                                                                                                     |
+| -h, --help, ?                    | Show this help page and exit                                                                                                                                                        |
+| -nu, --no-check-update           | Don't check for updates on startup                                                                                                                                                  |
+| -s, --sort                       | Sort results by: `size`, `path` or `last-mod`                                                                                                                                       |
+| -t, --target                     | Specify the name of the directories you want to search for (by default, it's 'node_modules'). You can define multiple targets separating with comma. Ej. `-t node_modules,.cache,`. |
+|                                  |
+| -x, --exclude-hidden-directories | Exclude hidden directories ("dot" directories) from search.                                                                                                                         |
+| --dry-run                        | It does not delete anything (will simulate it with a random delay).                                                                                                                 |
+| -v, --version                    | Show npkill version                                                                                                                                                                 |
 
 **Warning:** _In future versions some commands may change_
 

--- a/src/cli/cli.controller.ts
+++ b/src/cli/cli.controller.ts
@@ -155,7 +155,7 @@ export class CliController {
     changeConfig$.subscribe((configChanges) => {
       Object.assign(this.config, configChanges);
       if (
-        configChanges.targetFolder ||
+        configChanges.targets ||
         configChanges.folderRoot ||
         configChanges.excludeHiddenDirectories ||
         configChanges.exclude
@@ -273,7 +273,7 @@ export class CliController {
       this.config.checkUpdates = false;
     }
     if (options.isTrue('target-folder')) {
-      this.config.targetFolder = options.getString('target-folder');
+      this.config.targets = options.getString('target-folder').split(',');
     }
     if (options.isTrue('bg-color')) {
       this.setColor(options.getString('bg-color'));
@@ -512,10 +512,9 @@ export class CliController {
   }
 
   private prepareListDirParams() {
-    const target = this.config.targetFolder;
     const params = {
       rootPath: this.config.folderRoot,
-      targets: [target],
+      targets: this.config.targets,
     };
 
     if (this.config.exclude.length > 0) {
@@ -607,7 +606,7 @@ export class CliController {
       return;
     }
 
-    if (!isSafeToDelete(folder.path, this.config.targetFolder)) {
+    if (!isSafeToDelete(folder.path, this.config.targets)) {
       this.newError(`Folder not safe to delete: ${String(folder.path)}`);
       return;
     }

--- a/src/cli/interfaces/config.interface.ts
+++ b/src/cli/interfaces/config.interface.ts
@@ -8,7 +8,7 @@ export interface IConfig {
   maxSimultaneousSearch: number;
   showErrors: boolean;
   sortBy: string;
-  targetFolder: string;
+  targets: string[];
   exclude: string[];
   excludeHiddenDirectories: boolean;
   dryRun: boolean;

--- a/src/cli/ui/components/options.ui.ts
+++ b/src/cli/ui/components/options.ui.ts
@@ -61,8 +61,10 @@ export class OptionsUi extends BaseUi implements InteractiveUi {
       {
         label: 'Target folder',
         type: 'input',
-        key: 'targetFolder',
-        value: this.config.targetFolder,
+        key: 'targets',
+        value: Array.isArray(this.config.targets)
+          ? this.config.targets.join(',')
+          : '',
       },
       {
         label: 'Cwd',
@@ -71,10 +73,12 @@ export class OptionsUi extends BaseUi implements InteractiveUi {
         value: this.config.folderRoot,
       },
       {
-        label: 'Exlude',
+        label: 'Exclude',
         type: 'input',
         key: 'exclude',
-        value: this.config.exclude,
+        value: Array.isArray(this.config.exclude)
+          ? this.config.exclude.join(',')
+          : '',
       },
       {
         label: 'Sort by',
@@ -143,9 +147,20 @@ export class OptionsUi extends BaseUi implements InteractiveUi {
   private handleEditKey(name: string, sequence: string): void {
     if (name === 'return') {
       const opt = this.options[this.selectedIndex];
-      opt.value = this.editBuffer;
-      this.config[opt.key] = this.editBuffer;
-      this.emitConfigChange(opt.key, this.editBuffer);
+      let newValue = this.editBuffer;
+      if (opt.key === 'targets' || opt.key === 'exclude') {
+        const arrValue = this.editBuffer
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean);
+        this.config[opt.key] = arrValue;
+        this.emitConfigChange(opt.key, arrValue);
+        opt.value = this.editBuffer;
+      } else {
+        this.config[opt.key] = newValue;
+        this.emitConfigChange(opt.key, newValue);
+        opt.value = this.editBuffer;
+      }
       this.isEditing = false;
       this.render();
     } else if (name === 'escape') {

--- a/src/cli/ui/components/results.ui.ts
+++ b/src/cli/ui/components/results.ui.ts
@@ -135,7 +135,7 @@ export class ResultsUi extends HeavyUi implements InteractiveUi {
 
   private noResults(): void {
     const targetFolderColored: string = colors[DEFAULT_CONFIG.warningColor](
-      this.config.targetFolder,
+      this.config.targets,
     );
     const message = `No ${targetFolderColored} found!`;
     this.printAt(message, {

--- a/src/constants/cli.constants.ts
+++ b/src/constants/cli.constants.ts
@@ -65,7 +65,7 @@ export const OPTIONS: ICliOptions[] = [
   {
     arg: ['-t', '--target'],
     description:
-      "Specify the name of the directory you want to search for (by default, it's 'node_modules')",
+      "Specify the name of the directories you want to search for (by default, it's 'node_modules'). You can define multiple targets separating with comma. Ej. `-t node_modules,.cache,`.",
     name: 'target-folder',
   },
   {

--- a/src/constants/cli.constants.ts
+++ b/src/constants/cli.constants.ts
@@ -16,7 +16,7 @@ export const OPTIONS: ICliOptions[] = [
   },
   {
     arg: ['-D', '--delete-all'],
-    description: 'Auto-delete all node_modules folders that are found.',
+    description: 'Auto-delete all target folders that are found.',
     name: 'delete-all',
   },
   {
@@ -65,7 +65,7 @@ export const OPTIONS: ICliOptions[] = [
   {
     arg: ['-t', '--target'],
     description:
-      "Specify the name of the directory you want to search for (by default, it's node_modules)",
+      "Specify the name of the directory you want to search for (by default, it's 'node_modules')",
     name: 'target-folder',
   },
   {

--- a/src/constants/main.constants.ts
+++ b/src/constants/main.constants.ts
@@ -20,7 +20,7 @@ export const DEFAULT_CONFIG: IConfig = {
   maxSimultaneousSearch: 6,
   showErrors: true,
   sortBy: 'none',
-  targetFolder: 'node_modules',
+  targets: ['node_modules'],
   yes: false,
 };
 

--- a/src/core/services/files/files.service.ts
+++ b/src/core/services/files/files.service.ts
@@ -73,7 +73,7 @@ export abstract class FileService implements IFileService {
    * would imply breaking the application (until the dependencies are reinstalled).
    *
    * In the case of macOS applications and Windows AppData directory, these locations often contain
-   * application-specific data or configurations that should not be tampered with. Deleting node_modules
+   * application-specific data or configurations that should not be tampered with. Deleting directories
    * from these locations could potentially disrupt the normal operation of these applications.
    */
   isDangerous(originalPath: string): RiskAnalysis {
@@ -169,12 +169,15 @@ export abstract class FileService implements IFileService {
   }
 
   async getFileStatsInDir(dirname: string): Promise<IFileStat[]> {
+    const ignoredFolders = ['node_modules', '.git', 'coverage', 'dist'];
+
     let files: IFileStat[] = [];
     const items = await readdir(dirname, { withFileTypes: true });
 
     for (const item of items) {
       if (item.isDirectory()) {
-        if (item.name === 'node_modules') {
+        const itemNameLowerCase = item.name.toLowerCase();
+        if (ignoredFolders.includes(itemNameLowerCase)) {
           continue;
         }
         files = [

--- a/src/core/services/files/files.worker.ts
+++ b/src/core/services/files/files.worker.ts
@@ -272,7 +272,7 @@ class FileWalker {
   }
 
   private isTargetFolder(path: string): boolean {
-    return path === this.searchConfig.targets[0];
+    return this.searchConfig.targets.includes(path);
   }
 
   private completeTask(): void {

--- a/src/utils/is-safe-to-delete.ts
+++ b/src/utils/is-safe-to-delete.ts
@@ -1,3 +1,10 @@
-export function isSafeToDelete(path: string, targetFolder: string): boolean {
-  return path.includes(targetFolder);
+import * as path from 'path';
+
+export function isSafeToDelete(filePath: string, targets: string[]): boolean {
+  const lastPath = path.basename(filePath);
+  if (!lastPath) {
+    return false;
+  }
+
+  return targets.some((target) => target === lastPath);
 }

--- a/tests/utils/utils.test.ts
+++ b/tests/utils/utils.test.ts
@@ -26,7 +26,7 @@ describe('unit-conversions', () => {
 });
 
 describe('is-safe-to-delete', () => {
-  const target = 'node_modules';
+  const target = ['node_modules'];
 
   it('should get false if not is safe to delete ', () => {
     expect(isSafeToDelete('/one/route', target)).toBeFalsy();
@@ -35,10 +35,19 @@ describe('is-safe-to-delete', () => {
     expect(isSafeToDelete('/', target)).toBeFalsy();
     expect(isSafeToDelete('/home', target)).toBeFalsy();
     expect(isSafeToDelete('/home/user', target)).toBeFalsy();
+    expect(isSafeToDelete('/home/user/.angular', target)).toBeFalsy();
+    expect(
+      isSafeToDelete('/home/user/.angular', [...target, 'angular']),
+    ).toBeFalsy();
+    expect(isSafeToDelete('/home/user/dIst', [...target, 'dist'])).toBeFalsy();
   });
 
   it('should get true if is safe to delete ', () => {
     expect(isSafeToDelete('/one/route/node_modules', target)).toBeTruthy();
     expect(isSafeToDelete('/one/route/node_modules/', target)).toBeTruthy();
+    expect(
+      isSafeToDelete('/home/user/.angular', [...target, '.angular']),
+    ).toBeTruthy();
+    expect(isSafeToDelete('/home/user/dIst', [...target, 'dIst'])).toBeTruthy();
   });
 });


### PR DESCRIPTION
This PR adds the ability to define multiple targets with the `--targets` flag, separating each one with a comma.
Example:
`npkill --target node_modules,venv,log,tmp`

Close #173