### PR TITLE
Add json output mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ We're making an effort to internationalize the Npkill docs. Here's a list of the
 - [Usage](#usage)
   - [Options](#options)
   - [Examples](#examples)
+  - [JSON Output](#json-output)
 - [Set Up Locally](#setup-locally)
 - [API](#API)
 - [Roadmap](#roadmap)
@@ -114,6 +115,8 @@ To exit, <kbd>Q</kbd> or <kbd>Ctrl</kbd> + <kbd>c</kbd> if you're brave.
 |                                  |
 | -x, --exclude-hidden-directories | Exclude hidden directories ("dot" directories) from search.                                                                                                                         |
 | --dry-run                        | It does not delete anything (will simulate it with a random delay).                                                                                                                 |
+| --json                           | Output results in JSON format at the end of the scan. Useful for automation and scripting.                                                                                          |
+| --json-stream                    | Output results in streaming JSON format (one JSON object per line as results are found). Useful for real-time processing.                                                           |
 | -v, --version                    | Show npkill version                                                                                                                                                                 |
 
 **Warning:** _In future versions some commands may change_
@@ -160,6 +163,48 @@ npkill -d 'projects' --exclude "progress, ignore-this"
 
 ```bash
 npkill -d ~/backups/ --delete-all
+```
+
+- Get results in JSON format for automation or further processing:
+
+```bash
+npkill --json > results.json
+```
+
+- Stream results in real-time as JSON (useful for monitoring or piping to other tools):
+
+```bash
+npkill --json-stream | jq '.'
+```
+
+- Save only successful results to a file, ignoring errors:
+
+```bash
+npkill --json-stream 2>/dev/null | jq -s '.' > clean-results.json
+```
+
+<a name="json-output"></a>
+
+## JSON Output
+
+Npkill supports JSON output formats for automation and integration with other tools:
+
+- **`--json`**: Output all results as a single JSON object at the end of the scan
+- **`--json-stream`**: Output each result as a separate JSON object in real-time
+
+For detailed documentation, examples, and TypeScript interfaces, see [JSON Output Documentation](./docs/json-output.md).
+
+**Quick Examples:**
+
+```bash
+# Get all results as JSON
+npkill --json > results.json
+
+# Process results in real-time
+npkill --json-stream | jq '.result.path'
+
+# Find directories larger than 100MB
+npkill --json | jq '.results[] | select(.size > 104857600)'
 ```
 
 <a name="setup-locally"></a>

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -1,0 +1,205 @@
+# JSON Output
+
+Npkill supports two JSON output modes that allow you to integrate it into automation scripts, monitoring systems, or other tools.
+
+## Table of Contents
+
+- [Output Modes](#output-modes)
+- [JSON Structure](#json-structure)
+- [Examples](#examples)
+- [TypeScript Interfaces](#typescript-interfaces)
+- [Use Cases](#use-cases)
+
+## Output Modes
+
+### Simple JSON (`--json`)
+
+The `--json` option collects all results and outputs them as a single JSON object at the end of the scan. This is useful when you need all results at once for batch processing.
+
+```bash
+npkill --json
+```
+
+### Streaming JSON (`--json-stream`)
+
+The `--json-stream` option outputs each result as a separate JSON object on its own line as soon as it's found. This is useful for real-time processing or when dealing with large scans where you want to start processing results immediately.
+
+```bash
+npkill --json-stream
+```
+
+## JSON Structure
+
+### Simple JSON Output
+
+The simple JSON format includes all results in a single object with metadata:
+
+```json
+{
+  "version": 1,
+  "results": [
+    {
+      "path": "/home/user/project1/node_modules",
+      "size": 157286400,
+      "modificationTime": 1640995200000,
+      "riskAnalysis": {
+        "isSensitive": false
+      }
+    },
+    {
+      "path": "/home/user/project2/node_modules",
+      "size": 89478400,
+      "modificationTime": 1640995300000
+    }
+  ],
+  "meta": {
+    "resultsCount": 2,
+    "runDuration": 1523
+  }
+}
+```
+
+### Streaming JSON Output
+
+Each line in streaming mode contains a single result:
+
+```json
+{"version":1,"result":{"path":"/home/user/project1/node_modules","size":157286400,"modificationTime":1640995200000,"riskAnalysis":{"isSensitive":false}}}
+{"version":1,"result":{"path":"/home/user/project2/node_modules","size":89478400,"modificationTime":1640995300000}}
+```
+
+### Error Output
+
+Errors are output to stderr in JSON format:
+
+```json
+{
+  "version": 1,
+  "error": true,
+  "message": "Permission denied accessing /restricted/path",
+  "timestamp": "1640995300000"
+}
+```
+
+### Field Descriptions
+
+- **`version`**: Schema version.
+- **`path`**: Absolute path to the found directory.
+- **`size`**: Directory size in bytes.
+- **`modificationTime`**: Unix timestamp (milliseconds) of the most recently modified file.
+- **`riskAnalysis`**: Optional risk assessment for deletion
+  - **`isSensitive`**: Whether the directory might be important for system functionality.
+  - **`reason`**: Human-readable explanation of the risk assessment.
+- **`resultsCount`**: Total number of results found.
+- **`runDuration`**: Total scan time in milliseconds.
+
+## Examples
+
+### Basic Usage
+
+```bash
+# Get all results as JSON
+npkill --json > results.json
+
+# Stream results in real-time
+npkill --json-stream | while read line; do
+  echo "Found: $(echo $line | jq -r '.result.path')"
+done
+```
+
+### Using with jq for Processing
+
+```bash
+# Extract only paths larger than 100MB
+npkill --json | jq '.results[] | select(.size > 104857600) | .path'
+
+# Count total size of all node_modules
+npkill --json | jq '.results | map(.size) | add'
+
+# Get the 5 largest directories
+npkill --json | jq '.results | sort_by(.size) | reverse | .[0:5] | .[] | "\(.size | tostring) bytes: \(.path)"'
+
+# Convert streaming output to a valid JSON array
+npkill --json-stream | jq -s 'map(.result)'
+```
+
+### Error Handling
+
+```bash
+# Save results to file, ignore errors
+npkill --json 2>/dev/null > results.json
+
+# Save both results and errors to separate files
+npkill --json-stream > results.jsonl 2> errors.jsonl
+
+# Process only successful results in streaming mode
+npkill --json-stream 2>/dev/null | jq -r '.result.path'
+```
+
+### Automation Examples
+
+```bash
+# Find and delete directories older than 30 days
+npkill --json | jq -r '.results[] | select(.modificationTime < (now - 2592000) * 1000) | .path' | while read dir; do
+  echo "Deleting old directory: $dir"
+  rm -rf "$dir"
+done
+
+# Generate a report of space usage
+npkill --json | jq -r '.results[] | "\(.path): \(.size / 1048576 | floor)MB"' > space-report.txt
+
+# Monitor in real-time and alert on large directories
+npkill --json-stream | jq -r 'select(.result.size > 524288000) | "LARGE DIR: \(.result.path) (\(.result.size / 1048576 | floor)MB)"'
+```
+
+### Integration with Other Tools
+
+```bash
+# Send results to a monitoring system
+npkill --json-stream | while read line; do
+  curl -X POST -H "Content-Type: application/json" -d "$line" http://monitoring-system/api/npkill
+done
+
+# Create a CSV report
+echo "Path,Size(MB),LastModified,Status" > report.csv
+npkill --json | jq -r '.results[] | "\(.path),\(.size/1048576|floor),\(.modificationTime),\(.status)"' >> report.csv
+
+# Filter and format for human reading
+npkill --json | jq -r '.results[] | select(.size > 52428800) | "📁 \(.path)\n   💾 Size: \(.size/1048576|floor)MB\n   📅 Modified: \(.modificationTime | strftime("%Y-%m-%d %H:%M:%S"))\n"'
+```
+
+## Interfaces
+
+```typescript
+interface JsonOutputBase {
+  version: number;
+}
+
+interface JsonStreamOutput extends JsonOutputBase {
+  result: CliScanFoundFolder;
+}
+
+interface JsonSimpleOutput extends JsonOutputBase {
+  results: CliScanFoundFolder[];
+  meta: {
+    resultsCount: number;
+    runDuration: number; // milliseconds
+  };
+}
+
+interface JsonErrorOutput extends JsonOutputBase {
+  error: true;
+  message: string;
+  timestamp: string;
+}
+
+interface CliScanFoundFolder {
+  path: string;
+  size: number; // bytes
+  modificationTime: number; // Unix timestamp
+  riskAnalysis?: {
+    isSensitive: boolean;
+    reason?: string;
+  };
+}
+```

--- a/src/cli/cli.controller.ts
+++ b/src/cli/cli.controller.ts
@@ -512,7 +512,9 @@ export class CliController {
       .scan(this.config)
       .pipe(
         mergeMap((nodeFolder) =>
-          this.scanService.calculateFolderStats(nodeFolder),
+          this.scanService.calculateFolderStats(nodeFolder, {
+            getModificationTimeForSensitiveResults: true,
+          }),
         ),
         tap((folder) => this.jsonOutputService.processResult(folder)),
       )

--- a/src/cli/interfaces/config.interface.ts
+++ b/src/cli/interfaces/config.interface.ts
@@ -13,4 +13,5 @@ export interface IConfig {
   excludeHiddenDirectories: boolean;
   dryRun: boolean;
   yes: boolean;
+  jsonStream: boolean;
 }

--- a/src/cli/interfaces/config.interface.ts
+++ b/src/cli/interfaces/config.interface.ts
@@ -14,4 +14,5 @@ export interface IConfig {
   dryRun: boolean;
   yes: boolean;
   jsonStream: boolean;
+  jsonSimple: boolean;
 }

--- a/src/cli/interfaces/index.ts
+++ b/src/cli/interfaces/index.ts
@@ -8,3 +8,4 @@ export * from './stats.interface.js';
 export * from './ui-positions.interface.js';
 export * from './version.interface.js';
 export * from './node-version.interface.js';
+export * from './json-output.interface.js';

--- a/src/cli/interfaces/json-output.interface.ts
+++ b/src/cli/interfaces/json-output.interface.ts
@@ -1,0 +1,32 @@
+import { CliScanFoundFolder } from './stats.interface.js';
+
+export interface JsonOutputBase {
+  version: number;
+}
+
+/**
+ * JSON output format for streaming mode (--json-stream).
+ * Each result is output as a separate JSON object on its own line.
+ */
+export interface JsonStreamOutput extends JsonOutputBase {
+  result: CliScanFoundFolder;
+}
+
+/**
+ * JSON output format for simple mode (--json).
+ * All results are collected and output as a single JSON object at the end.
+ */
+export interface JsonSimpleOutput extends JsonOutputBase {
+  results: CliScanFoundFolder[];
+  meta: {
+    resultsCount: number;
+    /** Scan duration in milliseconds */
+    runDuration: number;
+  };
+}
+
+export interface JsonErrorOutput extends JsonOutputBase {
+  error: true;
+  message: string;
+  timestamp: string;
+}

--- a/src/cli/interfaces/json-output.interface.ts
+++ b/src/cli/interfaces/json-output.interface.ts
@@ -31,5 +31,5 @@ export interface JsonSimpleOutput extends JsonOutputBase {
 export interface JsonErrorOutput extends JsonOutputBase {
   error: true;
   message: string;
-  timestamp: string;
+  timestamp: number; // Unix timestamp in milliseconds
 }

--- a/src/cli/interfaces/json-output.interface.ts
+++ b/src/cli/interfaces/json-output.interface.ts
@@ -4,12 +4,15 @@ export interface JsonOutputBase {
   version: number;
 }
 
+export interface JsonCliScanFoundFolder
+  extends Omit<CliScanFoundFolder, 'status'> {}
+
 /**
  * JSON output format for streaming mode (--json-stream).
  * Each result is output as a separate JSON object on its own line.
  */
 export interface JsonStreamOutput extends JsonOutputBase {
-  result: CliScanFoundFolder;
+  result: JsonCliScanFoundFolder;
 }
 
 /**
@@ -17,7 +20,7 @@ export interface JsonStreamOutput extends JsonOutputBase {
  * All results are collected and output as a single JSON object at the end.
  */
 export interface JsonSimpleOutput extends JsonOutputBase {
-  results: CliScanFoundFolder[];
+  results: JsonCliScanFoundFolder[];
   meta: {
     resultsCount: number;
     /** Scan duration in milliseconds */

--- a/src/cli/services/index.ts
+++ b/src/cli/services/index.ts
@@ -3,4 +3,5 @@ export * from './https.service.js';
 export * from './results.service.js';
 export * from './spinner.service.js';
 export * from './update.service.js';
+export * from './json-output.service.js';
 export * from '../../core/services/stream.service.js';

--- a/src/cli/services/json-output.service.ts
+++ b/src/cli/services/json-output.service.ts
@@ -5,6 +5,7 @@ import {
   JsonErrorOutput,
   JsonCliScanFoundFolder,
 } from '../interfaces/json-output.interface.js';
+import { convertGbToBytes } from '../../utils/unit-conversions.js';
 
 export class JsonOutputService {
   private readonly OUTPUT_VERSION = 1;
@@ -107,7 +108,7 @@ export class JsonOutputService {
   ): JsonCliScanFoundFolder {
     return {
       path: folder.path,
-      size: folder.size,
+      size: convertGbToBytes(folder.size),
       modificationTime: folder.modificationTime,
       riskAnalysis: folder.riskAnalysis
         ? {

--- a/src/cli/services/json-output.service.ts
+++ b/src/cli/services/json-output.service.ts
@@ -3,11 +3,12 @@ import {
   JsonStreamOutput,
   JsonSimpleOutput,
   JsonErrorOutput,
+  JsonCliScanFoundFolder,
 } from '../interfaces/json-output.interface.js';
 
 export class JsonOutputService {
   private readonly OUTPUT_VERSION = 1;
-  private results: CliScanFoundFolder[] = [];
+  private results: JsonCliScanFoundFolder[] = [];
   private scanStartTime: number = 0;
   private isStreamMode: boolean = false;
 
@@ -103,12 +104,11 @@ export class JsonOutputService {
 
   private sanitizeFolderForOutput(
     folder: CliScanFoundFolder,
-  ): CliScanFoundFolder {
+  ): JsonCliScanFoundFolder {
     return {
       path: folder.path,
       size: folder.size,
       modificationTime: folder.modificationTime,
-      status: folder.status,
       riskAnalysis: folder.riskAnalysis
         ? {
             isSensitive: folder.riskAnalysis.isSensitive,

--- a/src/cli/services/json-output.service.ts
+++ b/src/cli/services/json-output.service.ts
@@ -86,7 +86,7 @@ export class JsonOutputService {
       version: this.OUTPUT_VERSION,
       error: true,
       message: errorMessage,
-      timestamp: new Date().toISOString(),
+      timestamp: new Date().getDate(),
     };
 
     this.stderr.write(JSON.stringify(errorOutput) + '\n');

--- a/src/cli/services/json-output.service.ts
+++ b/src/cli/services/json-output.service.ts
@@ -1,0 +1,120 @@
+import { CliScanFoundFolder } from '../interfaces/stats.interface.js';
+import {
+  JsonStreamOutput,
+  JsonSimpleOutput,
+  JsonErrorOutput,
+} from '../interfaces/json-output.interface.js';
+
+export class JsonOutputService {
+  private readonly OUTPUT_VERSION = 1;
+  private results: CliScanFoundFolder[] = [];
+  private scanStartTime: number = 0;
+  private isStreamMode: boolean = false;
+
+  constructor(
+    private readonly stdout: NodeJS.WriteStream = process.stdout,
+    private readonly stderr: NodeJS.WriteStream = process.stderr,
+  ) {}
+
+  initializeSession(streamMode: boolean = false): void {
+    this.results = [];
+    this.scanStartTime = Date.now();
+    this.isStreamMode = streamMode;
+  }
+
+  processResult(folder: CliScanFoundFolder): void {
+    if (this.isStreamMode) {
+      this.writeStreamResult(folder);
+    } else {
+      this.addResult(folder);
+    }
+  }
+
+  completeScan(): void {
+    if (!this.isStreamMode && this.results.length > 0) {
+      this.writeSimpleResults();
+    }
+  }
+
+  private writeStreamResult(folder: CliScanFoundFolder): void {
+    const output: JsonStreamOutput = {
+      version: this.OUTPUT_VERSION,
+      result: this.sanitizeFolderForOutput(folder),
+    };
+
+    try {
+      this.stdout.write(JSON.stringify(output) + '\n');
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error
+          ? error.message
+          : 'Unknown JSON serialization error';
+      this.writeError(`Failed to serialize result to JSON: ${errorMessage}`);
+    }
+  }
+
+  private addResult(folder: CliScanFoundFolder): void {
+    this.results.push(this.sanitizeFolderForOutput(folder));
+  }
+
+  private writeSimpleResults(): void {
+    const runDuration = Date.now() - this.scanStartTime;
+    const output: JsonSimpleOutput = {
+      version: this.OUTPUT_VERSION,
+      results: this.results,
+      meta: {
+        resultsCount: this.results.length,
+        runDuration,
+      },
+    };
+
+    try {
+      this.stdout.write(JSON.stringify(output, null, 2) + '\n');
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error
+          ? error.message
+          : 'Unknown JSON serialization error';
+      this.writeError(`Failed to serialize results to JSON: ${errorMessage}`);
+    }
+  }
+
+  writeError(error: Error | string): void {
+    const errorMessage = error instanceof Error ? error.message : error;
+    const errorOutput: JsonErrorOutput = {
+      version: this.OUTPUT_VERSION,
+      error: true,
+      message: errorMessage,
+      timestamp: new Date().toISOString(),
+    };
+
+    this.stderr.write(JSON.stringify(errorOutput) + '\n');
+  }
+
+  getResultsCount(): number {
+    return this.results.length;
+  }
+
+  handleShutdown(): void {
+    if (!this.isStreamMode && this.results.length > 0) {
+      this.writeSimpleResults();
+    }
+  }
+
+  private sanitizeFolderForOutput(
+    folder: CliScanFoundFolder,
+  ): CliScanFoundFolder {
+    return {
+      path: folder.path,
+      size: folder.size,
+      modificationTime: folder.modificationTime,
+      status: folder.status,
+      riskAnalysis: folder.riskAnalysis
+        ? {
+            isSensitive: folder.riskAnalysis.isSensitive,
+            reason: folder.riskAnalysis.reason,
+          }
+        : undefined,
+    };
+  }
+}

--- a/src/constants/cli.constants.ts
+++ b/src/constants/cli.constants.ts
@@ -81,6 +81,11 @@ export const OPTIONS: ICliOptions[] = [
     name: 'dry-run',
   },
   {
+    arg: ['--json-stream'],
+    description: 'Output results in a stream JSON format.',
+    name: 'jsonStream',
+  },
+  {
     arg: ['-v', '--version'],
     description: 'Show version.',
     name: 'version',

--- a/src/constants/cli.constants.ts
+++ b/src/constants/cli.constants.ts
@@ -86,6 +86,11 @@ export const OPTIONS: ICliOptions[] = [
     name: 'jsonStream',
   },
   {
+    arg: ['--json'],
+    description: 'Output results in a JSON format.',
+    name: 'jsonSimple',
+  },
+  {
     arg: ['-v', '--version'],
     description: 'Show version.',
     name: 'version',

--- a/src/constants/main.constants.ts
+++ b/src/constants/main.constants.ts
@@ -23,6 +23,7 @@ export const DEFAULT_CONFIG: IConfig = {
   targets: ['node_modules'],
   yes: false,
   jsonStream: false,
+  jsonSimple: false,
 };
 
 export const MARGINS = {

--- a/src/constants/main.constants.ts
+++ b/src/constants/main.constants.ts
@@ -22,6 +22,7 @@ export const DEFAULT_CONFIG: IConfig = {
   sortBy: 'none',
   targets: ['node_modules'],
   yes: false,
+  jsonStream: false,
 };
 
 export const MARGINS = {

--- a/src/constants/messages.constants.ts
+++ b/src/constants/messages.constants.ts
@@ -40,6 +40,8 @@ export const ERROR_MSG = {
   CANT_DELETE_FOLDER:
     'The directory cannot be deleted. Do you have permission?',
   CANT_GET_REMOTE_VERSION: 'Couldnt check for updates',
+  CANT_USE_BOTH_JSON_OPTIONS:
+    'Cannot use both --json and --json-stream options simultaneously.',
 };
 
 export const RESULT_TYPE_INFO = {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import {
   ConsoleService,
   HttpsService,
+  JsonOutputService,
   ResultsService,
   SpinnerService,
   UpdateService,
@@ -20,7 +21,11 @@ export default (): void => {
 
   const npkill = new Npkill({ logger, searchStatus, resultsService });
 
+  const stdOut = process.stdout;
+  const jsonOutputService = new JsonOutputService(stdOut, process.stderr);
+
   const cli = new CliController(
+    stdOut,
     npkill,
     logger,
     searchStatus,
@@ -30,6 +35,7 @@ export default (): void => {
     new UpdateService(new HttpsService()),
     new UiService(),
     new ScanService(npkill),
+    jsonOutputService,
   );
 
   cli.init();

--- a/src/utils/unit-conversions.ts
+++ b/src/utils/unit-conversions.ts
@@ -16,3 +16,7 @@ export function convertGbToKb(gb: number): number {
   const factorGBtoKB = 1024 * 1024;
   return gb * factorGBtoKB;
 }
+
+export function convertGbToBytes(gb: number): number {
+  return gb * Math.pow(1024, 3);
+}

--- a/src/utils/unit-conversions.ts
+++ b/src/utils/unit-conversions.ts
@@ -11,3 +11,8 @@ export function convertGBToMB(gb: number): number {
   const factorGBtoMB = 1024;
   return gb * factorGBtoMB;
 }
+
+export function convertGbToKb(gb: number): number {
+  const factorGBtoKB = 1024 * 1024;
+  return gb * factorGBtoKB;
+}

--- a/tests/cli/cli.controller.test.ts
+++ b/tests/cli/cli.controller.test.ts
@@ -9,6 +9,8 @@ import { ConsoleService } from '../../src/cli/services/console.service.js';
 import { UpdateService } from '../../src/cli/services/update.service.js';
 import { UiService } from '../../src/cli/services/ui.service.js';
 import { ScanService } from '../../src/cli/services/scan.service.js';
+import { ERROR_MSG } from '../../src/constants/messages.constants.js';
+import { JsonOutputService } from '../../src/cli/services/json-output.service.js';
 
 const resultsUiDeleteMock$ = new Subject<DeleteResult>();
 const setDeleteAllWarningVisibilityMock = jest.fn();
@@ -126,6 +128,12 @@ describe('CliController test', () => {
     startListenKeyEvents: jest.fn(),
   };
 
+  const jsonOutputServiceMock = {
+    initializeSession: jest.fn(),
+    writeStreamResult: jest.fn(),
+    getResultsCount: jest.fn(() => 0),
+  };
+
   const npkillDeleteMock = jest.fn();
   const npkillMock: Npkill = {
     logger: loggerServiceMock,
@@ -149,6 +157,7 @@ describe('CliController test', () => {
       throw new Error('process.exit: ' + number);
     });
     cliController = new CliController(
+      process.stdout,
       npkillMock,
       loggerServiceMock as LoggerService,
       searchStatusMock as unknown as ScanStatus,
@@ -158,6 +167,7 @@ describe('CliController test', () => {
       updateServiceMock as unknown as UpdateService,
       uiServiceMock as unknown as UiService,
       scanServiceMock as unknown as ScanService,
+      jsonOutputServiceMock as unknown as JsonOutputService,
     );
 
     Object.defineProperty(process.stdout, 'columns', { value: 80 });
@@ -307,6 +317,42 @@ describe('CliController test', () => {
         expect(npkillDeleteMock).toHaveBeenCalledWith(testFolder.path, {
           dryRun: true,
         });
+      });
+    });
+
+    describe('--json and --json-stream options', () => {
+      it('Should enable JSON stream mode when --json-stream is provided', () => {
+        mockParameters({ jsonStream: true });
+        const setupJsonSignalsSpy = spyMethod('setupJsonModeSignalHandlers');
+        const exitWithErrorSpy = spyMethod('exitWithError');
+
+        cliController.init();
+
+        expect(setupJsonSignalsSpy).toHaveBeenCalledTimes(1);
+        expect(scanSpy).toHaveBeenCalledTimes(1);
+      });
+
+      it('Should enable JSON simple mode when --json is provided', () => {
+        mockParameters({ jsonSimple: true });
+        const setupJsonSignalsSpy = spyMethod('setupJsonModeSignalHandlers');
+        const exitWithErrorSpy = spyMethod('exitWithError');
+
+        cliController.init();
+
+        expect(setupJsonSignalsSpy).toHaveBeenCalledTimes(1);
+        expect(scanSpy).toHaveBeenCalledTimes(1);
+      });
+
+      it('Should show error and exit when both --json and --json-stream are provided', () => {
+        mockParameters({ jsonSimple: true, jsonStream: true });
+        const exitWithErrorSpy = spyMethod('exitWithError');
+
+        cliController.init();
+
+        expect(loggerServiceMock.error).toHaveBeenCalledWith(
+          ERROR_MSG.CANT_USE_BOTH_JSON_OPTIONS,
+        );
+        expect(exitWithErrorSpy).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/tests/cli/services/json-output.service.test.ts
+++ b/tests/cli/services/json-output.service.test.ts
@@ -141,7 +141,7 @@ describe('JsonOutputService', () => {
         version: 1,
         error: true,
         message: 'Test error message',
-        timestamp: expect.any(String),
+        timestamp: expect.any(Number),
       });
     });
 
@@ -157,7 +157,7 @@ describe('JsonOutputService', () => {
         version: 1,
         error: true,
         message: 'String error message',
-        timestamp: expect.any(String),
+        timestamp: expect.any(Number),
       });
     });
   });

--- a/tests/cli/services/json-output.service.test.ts
+++ b/tests/cli/services/json-output.service.test.ts
@@ -51,7 +51,7 @@ describe('JsonOutputService', () => {
         version: 1,
         result: {
           path: '/test/node_modules',
-          size: 1024,
+          size: 1099511627776,
           modificationTime: 1640995200000,
           riskAnalysis: {
             isSensitive: false,
@@ -94,12 +94,12 @@ describe('JsonOutputService', () => {
         results: [
           {
             path: '/test/node_modules',
-            size: 1024,
+            size: 1099511627776,
             modificationTime: 1640995200000,
           },
           {
             path: '/test2/node_modules',
-            size: 2048,
+            size: 2199023255552,
             modificationTime: 1640995300000,
           },
         ],

--- a/tests/cli/services/json-output.service.test.ts
+++ b/tests/cli/services/json-output.service.test.ts
@@ -1,0 +1,213 @@
+import { jest } from '@jest/globals';
+import { JsonOutputService } from '../../../src/cli/services/json-output.service.js';
+import { CliScanFoundFolder } from '../../../src/cli/interfaces/stats.interface.js';
+
+describe('JsonOutputService', () => {
+  let jsonOutputService: JsonOutputService;
+  let mockStdout: any;
+  let mockStderr: any;
+
+  beforeEach(() => {
+    mockStdout = {
+      write: jest.fn(),
+    };
+    mockStderr = {
+      write: jest.fn(),
+    };
+    jsonOutputService = new JsonOutputService(mockStdout, mockStderr);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('initializeSession', () => {
+    it('should initialize session correctly', () => {
+      jsonOutputService.initializeSession();
+      expect(jsonOutputService.getResultsCount()).toBe(0);
+    });
+  });
+
+  describe('processResult in stream mode', () => {
+    it('should write stream result in correct format', () => {
+      const mockFolder: CliScanFoundFolder = {
+        path: '/test/node_modules',
+        size: 1024,
+        modificationTime: 1640995200000,
+        status: 'live',
+        riskAnalysis: {
+          isSensitive: false,
+        },
+      };
+
+      jsonOutputService.initializeSession(true); // stream mode
+      jsonOutputService.processResult(mockFolder);
+
+      expect(mockStdout.write).toHaveBeenCalledTimes(1);
+      const writtenData = mockStdout.write.mock.calls[0][0];
+      const parsedData = JSON.parse(writtenData.trim());
+
+      expect(parsedData).toMatchObject({
+        version: 1,
+        result: {
+          path: '/test/node_modules',
+          size: 1024,
+          modificationTime: 1640995200000,
+          status: 'live',
+          riskAnalysis: {
+            isSensitive: false,
+          },
+        },
+      });
+    });
+  });
+
+  describe('processResult and completeScan in simple mode', () => {
+    it('should collect results and output them in simple format', () => {
+      const mockFolder1: CliScanFoundFolder = {
+        path: '/test/node_modules',
+        size: 1024,
+        modificationTime: 1640995200000,
+        status: 'live',
+      };
+
+      const mockFolder2: CliScanFoundFolder = {
+        path: '/test2/node_modules',
+        size: 2048,
+        modificationTime: 1640995300000,
+        status: 'deleted',
+      };
+
+      jsonOutputService.initializeSession(false); // simple mode
+      jsonOutputService.processResult(mockFolder1);
+      jsonOutputService.processResult(mockFolder2);
+
+      expect(jsonOutputService.getResultsCount()).toBe(2);
+
+      jsonOutputService.completeScan();
+
+      expect(mockStdout.write).toHaveBeenCalledTimes(1);
+      const writtenData = mockStdout.write.mock.calls[0][0];
+      const parsedData = JSON.parse(writtenData.trim());
+
+      expect(parsedData).toMatchObject({
+        version: 1,
+        results: [
+          {
+            path: '/test/node_modules',
+            size: 1024,
+            modificationTime: 1640995200000,
+            status: 'live',
+          },
+          {
+            path: '/test2/node_modules',
+            size: 2048,
+            modificationTime: 1640995300000,
+            status: 'deleted',
+          },
+        ],
+        meta: {
+          resultsCount: 2,
+          runDuration: expect.any(Number),
+        },
+      });
+    });
+
+    it('should not output anything on completeScan in stream mode', () => {
+      const mockFolder: CliScanFoundFolder = {
+        path: '/test/node_modules',
+        size: 1024,
+        modificationTime: 1640995200000,
+        status: 'live',
+      };
+
+      jsonOutputService.initializeSession(true); // stream mode
+      jsonOutputService.processResult(mockFolder);
+      mockStdout.write.mockClear();
+
+      jsonOutputService.completeScan();
+
+      expect(mockStdout.write).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('writeError', () => {
+    it('should write error in correct format when given Error object', () => {
+      const error = new Error('Test error message');
+      jsonOutputService.writeError(error);
+
+      expect(mockStderr.write).toHaveBeenCalledTimes(1);
+      const writtenData = mockStderr.write.mock.calls[0][0];
+      const parsedData = JSON.parse(writtenData.trim());
+
+      expect(parsedData).toMatchObject({
+        version: 1,
+        error: true,
+        message: 'Test error message',
+        timestamp: expect.any(String),
+      });
+    });
+
+    it('should write error in correct format when given string', () => {
+      const error = 'String error message';
+      jsonOutputService.writeError(error);
+
+      expect(mockStderr.write).toHaveBeenCalledTimes(1);
+      const writtenData = mockStderr.write.mock.calls[0][0];
+      const parsedData = JSON.parse(writtenData.trim());
+
+      expect(parsedData).toMatchObject({
+        version: 1,
+        error: true,
+        message: 'String error message',
+        timestamp: expect.any(String),
+      });
+    });
+  });
+
+  describe('handleShutdown', () => {
+    it('should output collected results when shutdown is called in simple mode', () => {
+      const mockFolder: CliScanFoundFolder = {
+        path: '/test/node_modules',
+        size: 1024,
+        modificationTime: 1640995200000,
+        status: 'live',
+      };
+
+      jsonOutputService.initializeSession(false); // simple mode
+      jsonOutputService.processResult(mockFolder);
+      jsonOutputService.handleShutdown();
+
+      expect(mockStdout.write).toHaveBeenCalledTimes(1);
+      const writtenData = mockStdout.write.mock.calls[0][0];
+      const parsedData = JSON.parse(writtenData.trim());
+
+      expect(parsedData.results).toHaveLength(1);
+      expect(parsedData.results[0].path).toBe('/test/node_modules');
+    });
+
+    it('should not output anything when no results collected', () => {
+      jsonOutputService.initializeSession(false); // simple mode
+      jsonOutputService.handleShutdown();
+
+      expect(mockStdout.write).not.toHaveBeenCalled();
+    });
+
+    it('should not output anything in stream mode', () => {
+      const mockFolder: CliScanFoundFolder = {
+        path: '/test/node_modules',
+        size: 1024,
+        modificationTime: 1640995200000,
+        status: 'live',
+      };
+
+      jsonOutputService.initializeSession(true); // stream mode
+      jsonOutputService.processResult(mockFolder); // This writes to stdout
+      mockStdout.write.mockClear(); // Clear the call from processResult
+
+      jsonOutputService.handleShutdown();
+
+      expect(mockStdout.write).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/cli/services/json-output.service.test.ts
+++ b/tests/cli/services/json-output.service.test.ts
@@ -53,7 +53,6 @@ describe('JsonOutputService', () => {
           path: '/test/node_modules',
           size: 1024,
           modificationTime: 1640995200000,
-          status: 'live',
           riskAnalysis: {
             isSensitive: false,
           },
@@ -97,13 +96,11 @@ describe('JsonOutputService', () => {
             path: '/test/node_modules',
             size: 1024,
             modificationTime: 1640995200000,
-            status: 'live',
           },
           {
             path: '/test2/node_modules',
             size: 2048,
             modificationTime: 1640995300000,
-            status: 'deleted',
           },
         ],
         meta: {

--- a/tests/cli/services/scan.service.test.ts
+++ b/tests/cli/services/scan.service.test.ts
@@ -34,6 +34,7 @@ describe('ScanService', () => {
     dryRun: false,
     yes: false,
     jsonStream: false,
+    jsonSimple: false,
   };
 
   const mockScanFoundFolder: ScanFoundFolder = {

--- a/tests/cli/services/scan.service.test.ts
+++ b/tests/cli/services/scan.service.test.ts
@@ -33,6 +33,7 @@ describe('ScanService', () => {
     showErrors: false,
     dryRun: false,
     yes: false,
+    jsonStream: false,
   };
 
   const mockScanFoundFolder: ScanFoundFolder = {

--- a/tests/core/npkill.test.ts
+++ b/tests/core/npkill.test.ts
@@ -107,7 +107,6 @@ describe('Npkill', () => {
       const mockFolderData = 'folder1\nfolder2\nfolder3';
       const mockRiskAnalysis: RiskAnalysis = {
         isSensitive: false,
-        reason: 'Safe to delete',
       };
 
       fileServiceMock.listDir.mockReturnValue(of(mockFolderData));


### PR DESCRIPTION
## Simple JSON (`--json`)

The `--json` option collects all results and outputs them as a single JSON object at the end of the scan. This is useful when you need all results at once for batch processing.

```bash
npkill --json
```

## Streaming JSON (`--json-stream`)

The `--json-stream` option outputs each result as a separate JSON object on its own line as soon as it's found. This is useful for real-time processing or when dealing with large scans where you want to start processing results immediately.

```bash
npkill --json-stream
```

## Output
###  `--json`

```json
{
  "version": 1,
  "results": [
    {
      "path": "/home/user/project1/node_modules",
      "size": 157286400,
      "modificationTime": 1640995200000,
      "riskAnalysis": {
        "isSensitive": false
      }
    },
    {
      "path": "/home/user/project2/node_modules",
      "size": 89478400,
      "modificationTime": 1640995300000
    }
  ],
  "meta": {
    "resultsCount": 2,
    "runDuration": 1523
  }
}
```

### `--json-stream`

```json
{"version":1,"result":{"path":"/home/user/project1/node_modules","size":157286400,"modificationTime":1640995200000,"riskAnalysis":{"isSensitive":false}}}
{"version":1,"result":{"path":"/home/user/project2/node_modules","size":89478400,"modificationTime":1640995300000}}
```

---

Close #194 