### PR TITLE
feat: added --disable-size flag and related handling

### DIFF
--- a/src/cli/cli.controller.ts
+++ b/src/cli/cli.controller.ts
@@ -138,7 +138,11 @@ export class CliController {
   private initUi(): void {
     this.uiHeader = new HeaderUi(this.config);
     this.uiService.add(this.uiHeader);
-    this.uiResults = new ResultsUi(this.resultsService, this.consoleService);
+    this.uiResults = new ResultsUi(
+      this.resultsService,
+      this.consoleService,
+      this.config,
+    );
     this.uiService.add(this.uiResults);
     this.uiStats = new StatsUi(this.config, this.resultsService, this.logger);
     this.uiService.add(this.uiStats);
@@ -535,6 +539,10 @@ export class CliController {
       this.config.jsonSimple = true;
     }
 
+    if (options.isTrue('disable-size')) {
+      this.config.disableSize = true;
+    }
+
     if (this.config.jsonStream && this.config.jsonSimple) {
       this.logger.error(ERROR_MSG.CANT_USE_BOTH_JSON_OPTIONS);
       this.exitWithError();
@@ -756,21 +764,31 @@ export class CliController {
     this.uiStatus.start();
     this.searchStart = Date.now();
 
-    this.scanSubscription = this.scanService
+    const scan$ = this.scanService
       .scan(this.config)
-      .pipe(
-        tap((nodeFolder) => this.processNodeFolderForUi(nodeFolder)),
-        mergeMap(
-          (nodeFolder) => this.scanService.calculateFolderStats(nodeFolder),
-          10, // Limit to 10 concurrent stat calculations at a time
-        ),
-        tap((folder) => this.processFolderStatsForUi(folder)),
-      )
-      .subscribe({
+      .pipe(tap((nodeFolder) => this.processNodeFolderForUi(nodeFolder)));
+
+    if (this.config.disableSize) {
+      this.scanSubscription = scan$.subscribe({
         next: () => this.printFoldersSection(),
         error: (error) => this.newError(error),
         complete: () => this.completeSearch(),
       });
+    } else {
+      this.scanSubscription = scan$
+        .pipe(
+          mergeMap(
+            (nodeFolder) => this.scanService.calculateFolderStats(nodeFolder),
+            10, // Limit to 10 concurrent stat calculations at a time
+          ),
+          tap((folder) => this.processFolderStatsForUi(folder)),
+        )
+        .subscribe({
+          next: () => this.printFoldersSection(),
+          error: (error) => this.newError(error),
+          complete: () => this.completeSearch(),
+        });
+    }
   }
 
   private setupJsonModeSignalHandlers(): void {
@@ -790,6 +808,10 @@ export class CliController {
     if (this.config.sortBy === 'path') {
       this.resultsService.sortResults(this.config.sortBy);
       this.uiResults.clear();
+    }
+
+    if (this.config.disableSize && this.config.deleteAll) {
+      this.deleteFolder(nodeFolder);
     }
 
     this.uiResults.render();

--- a/src/cli/cli.controller.ts
+++ b/src/cli/cli.controller.ts
@@ -768,27 +768,22 @@ export class CliController {
       .scan(this.config)
       .pipe(tap((nodeFolder) => this.processNodeFolderForUi(nodeFolder)));
 
-    if (this.config.disableSize) {
-      this.scanSubscription = scan$.subscribe({
+    this.scanSubscription = scan$
+      .pipe(
+        mergeMap(
+          (nodeFolder) =>
+            this.scanService.calculateFolderStats(nodeFolder, {
+              disableSize: this.config.disableSize,
+            }),
+          10, // Limit to 10 concurrent stat calculations at a time
+        ),
+        tap((folder) => this.processFolderStatsForUi(folder)),
+      )
+      .subscribe({
         next: () => this.printFoldersSection(),
         error: (error) => this.newError(error),
         complete: () => this.completeSearch(),
       });
-    } else {
-      this.scanSubscription = scan$
-        .pipe(
-          mergeMap(
-            (nodeFolder) => this.scanService.calculateFolderStats(nodeFolder),
-            10, // Limit to 10 concurrent stat calculations at a time
-          ),
-          tap((folder) => this.processFolderStatsForUi(folder)),
-        )
-        .subscribe({
-          next: () => this.printFoldersSection(),
-          error: (error) => this.newError(error),
-          complete: () => this.completeSearch(),
-        });
-    }
   }
 
   private setupJsonModeSignalHandlers(): void {

--- a/src/cli/interfaces/config.interface.ts
+++ b/src/cli/interfaces/config.interface.ts
@@ -14,4 +14,5 @@ export interface IConfig {
   yes: boolean;
   jsonStream: boolean;
   jsonSimple: boolean;
+  disableSize: boolean;
 }

--- a/src/cli/services/scan.service.ts
+++ b/src/cli/services/scan.service.ts
@@ -22,7 +22,8 @@ import { join } from 'path';
 import os from 'os';
 
 export interface CalculateFolderStatsOptions {
-  getModificationTimeForSensitiveResults: boolean;
+  getModificationTimeForSensitiveResults?: boolean;
+  disableSize?: boolean;
 }
 
 export class ScanService {
@@ -67,17 +68,22 @@ export class ScanService {
       getModificationTimeForSensitiveResults: false,
     },
   ): Observable<CliScanFoundFolder> {
-    return this.npkill.getSize$(nodeFolder.path).pipe(
-      timeout(30000), // 30 seconds timeout
-      catchError(() => {
-        // If size calculation fails or times out, keep size as 0 but mark as calculated
-        nodeFolder.size = 0;
-        nodeFolder.modificationTime = 1; // 1 = calculated, -1 = not calculated
-        return of({ size: 0, unit: 'bytes' as const });
-      }),
-      tap(({ size }) => {
-        nodeFolder.size = convertBytesToGb(size);
-      }),
+    const size$ = options.disableSize
+      ? of({ size: 0, unit: 'bytes' as const })
+      : this.npkill.getSize$(nodeFolder.path).pipe(
+          timeout(30000), // 30 seconds timeout
+          catchError(() => {
+            // If size calculation fails or times out, keep size as 0 but mark as calculated
+            nodeFolder.size = 0;
+            nodeFolder.modificationTime = 1; // 1 = calculated, -1 = not calculated
+            return of({ size: 0, unit: 'bytes' as const });
+          }),
+          tap(({ size }) => {
+            nodeFolder.size = convertBytesToGb(size);
+          }),
+        );
+
+    return size$.pipe(
       switchMap(async () => {
         if (
           nodeFolder.riskAnalysis?.isSensitive &&

--- a/src/cli/ui/components/results.ui.ts
+++ b/src/cli/ui/components/results.ui.ts
@@ -47,7 +47,7 @@ export class ResultsUi extends HeavyUi implements InteractiveUi {
   private searchText = '';
   private filteredResults: CliScanFoundFolder[] = [];
 
-  private readonly config: IConfig = DEFAULT_CONFIG;
+  private config: IConfig = DEFAULT_CONFIG;
   private readonly KEYS = {
     up: () => this.cursorUp(),
     down: () => this.cursorDown(),
@@ -78,8 +78,12 @@ export class ResultsUi extends HeavyUi implements InteractiveUi {
   constructor(
     private readonly resultsService: ResultsService,
     private readonly consoleService: ConsoleService,
+    config?: IConfig,
   ) {
     super();
+    if (config) {
+      this.config = config;
+    }
   }
 
   private openFolder(): void {
@@ -512,7 +516,12 @@ export class ResultsUi extends HeavyUi implements InteractiveUi {
     // Only show "..." if size is exactly 0 AND modificationTime is -1 (not yet calculated)
     // If size is 0 but modificationTime is set, then it's a truly empty folder
     const isCalculating = folder.size === 0 && folder.modificationTime === -1;
-    const folderSizeText = isCalculating ? pc.gray('   .....') : folderSize;
+    let folderSizeText: string;
+    if (this.config.disableSize) {
+      folderSizeText = pc.gray('     ...');
+    } else {
+      folderSizeText = isCalculating ? pc.gray('   .....') : folderSize;
+    }
 
     return {
       path: folderText,

--- a/src/constants/cli.constants.ts
+++ b/src/constants/cli.constants.ts
@@ -97,6 +97,12 @@ export const OPTIONS: ICliOptions[] = [
     name: 'jsonSimple',
   },
   {
+    arg: ['--disable-size'],
+    description:
+      'Skip size and age calculation. Useful for faster scanning and deletion when space info is not needed.',
+    name: 'disable-size',
+  },
+  {
     arg: ['-v', '--version'],
     description: 'Show version.',
     name: 'version',

--- a/src/constants/main.constants.ts
+++ b/src/constants/main.constants.ts
@@ -24,6 +24,7 @@ export const DEFAULT_CONFIG: IConfig = {
   yes: false,
   jsonStream: false,
   jsonSimple: false,
+  disableSize: false,
 };
 
 export const MARGINS = {

--- a/tests/cli/services/scan.service.test.ts
+++ b/tests/cli/services/scan.service.test.ts
@@ -35,6 +35,7 @@ describe('ScanService', () => {
     yes: false,
     jsonStream: false,
     jsonSimple: false,
+    disableSize: false,
   };
 
   const mockScanFoundFolder: ScanFoundFolder = {


### PR DESCRIPTION
For #240 

## Changes

  - Added `disableSize` to the CLI config interface and default config.
  - Registered the `--disable-size` option in CLI help/options.
  - Passed CLI config into `ResultsUi` so result rendering can react to `disableSize`.
  - Updated result display to show placeholder size text when size calculation is disabled.
  - Updated UI scan flow to skip `calculateFolderStats()` when `disableSize` is enabled.
  - Updated `--delete-all` handling so folders can be deleted as soon as they are found when size calculation is disabled.
  - Updated test config fixture to include the new `disableSize` field.

  ## Validation

  - `npm run build` passes.
  - `npm test` passes.
  - Verified `node lib/index.js --help` shows `--disable-size`.

  ## Note

  `--disable-size` currently affects interactive UI mode.