### PR TITLE
feat: add --disable-age and --disable-stats flags

### DIFF
--- a/src/cli/cli.controller.ts
+++ b/src/cli/cli.controller.ts
@@ -543,6 +543,15 @@ export class CliController {
       this.config.disableSize = true;
     }
 
+    if (options.isTrue('disable-age')) {
+      this.config.disableAge = true;
+    }
+
+    if (options.isTrue('disable-stats')) {
+      this.config.disableSize = true;
+      this.config.disableAge = true;
+    }
+
     if (this.config.jsonStream && this.config.jsonSimple) {
       this.logger.error(ERROR_MSG.CANT_USE_BOTH_JSON_OPTIONS);
       this.exitWithError();
@@ -774,6 +783,7 @@ export class CliController {
           (nodeFolder) =>
             this.scanService.calculateFolderStats(nodeFolder, {
               disableSize: this.config.disableSize,
+              disableAge: this.config.disableAge,
             }),
           10, // Limit to 10 concurrent stat calculations at a time
         ),

--- a/src/cli/interfaces/config.interface.ts
+++ b/src/cli/interfaces/config.interface.ts
@@ -15,4 +15,6 @@ export interface IConfig {
   jsonStream: boolean;
   jsonSimple: boolean;
   disableSize: boolean;
+  disableAge: boolean;
+  disableStats: boolean;
 }

--- a/src/cli/services/scan.service.ts
+++ b/src/cli/services/scan.service.ts
@@ -24,6 +24,7 @@ import os from 'os';
 export interface CalculateFolderStatsOptions {
   getModificationTimeForSensitiveResults?: boolean;
   disableSize?: boolean;
+  disableAge?: boolean;
 }
 
 export class ScanService {
@@ -85,6 +86,11 @@ export class ScanService {
 
     return size$.pipe(
       switchMap(async () => {
+        if (options.disableAge) {
+          nodeFolder.modificationTime = 1;
+          return nodeFolder;
+        }
+
         if (
           nodeFolder.riskAnalysis?.isSensitive &&
           !options.getModificationTimeForSensitiveResults

--- a/src/cli/ui/components/results.ui.ts
+++ b/src/cli/ui/components/results.ui.ts
@@ -500,6 +500,10 @@ export class ResultsUi extends HeavyUi implements InteractiveUi {
       daysSinceLastModification = '';
     }
 
+    if (this.config.disableAge) {
+      daysSinceLastModification = pc.gray('  ...');
+    }
+
     // Align to right
     const alignMargin = 4 - daysSinceLastModification.length;
     daysSinceLastModification =

--- a/src/constants/cli.constants.ts
+++ b/src/constants/cli.constants.ts
@@ -103,6 +103,17 @@ export const OPTIONS: ICliOptions[] = [
     name: 'disable-size',
   },
   {
+    arg: ['--disable-age'],
+    description: 'Skip age (last modification time) calculation.',
+    name: 'disable-age',
+  },
+  {
+    arg: ['--disable-stats'],
+    description:
+      'Skip both size and age calculation. Shortcut for --disable-size --disable-age.',
+    name: 'disable-stats',
+  },
+  {
     arg: ['-v', '--version'],
     description: 'Show version.',
     name: 'version',

--- a/src/constants/main.constants.ts
+++ b/src/constants/main.constants.ts
@@ -25,6 +25,8 @@ export const DEFAULT_CONFIG: IConfig = {
   jsonStream: false,
   jsonSimple: false,
   disableSize: false,
+  disableAge: false,
+  disableStats: false,
 };
 
 export const MARGINS = {

--- a/tests/cli/services/scan.service.test.ts
+++ b/tests/cli/services/scan.service.test.ts
@@ -36,6 +36,8 @@ describe('ScanService', () => {
     jsonStream: false,
     jsonSimple: false,
     disableSize: false,
+    disableAge: false,
+    disableStats: false,
   };
 
   const mockScanFoundFolder: ScanFoundFolder = {


### PR DESCRIPTION
Closes #249

## Changes

- Added `disableAge` and `disableStats` to the CLI config interface and default config.
- Registered `--disable-age` and `--disable-stats` options in CLI help/options.
- Added `disableAge` to `CalculateFolderStatsOptions` in `scan.service.ts`.
- Updated `calculateFolderStats()` to skip modification time calculation when `disableAge` is enabled.
- Updated result display to show placeholder text in Age column when `--disable-age` is enabled.
- Implemented `--disable-stats` as a shortcut that enables both `--disable-size` and `--disable-age`.
- Updated test config fixture to include the new fields.

## Validation

- `npm test` passes.
- Verified `--disable-age` shows `..` in the Age column instead of calculating modification time.
- Verified `--disable-stats` disables both Size and Age columns.

## Note

`--disable-age` and `--disable-stats` currently affect interactive UI mode.