### PR TITLE
Add llms.txt for LLM/agent-readable project summary

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,27 @@
+# npkill
+
+> A CLI tool to list `node_modules` directories anywhere on your system, show how much disk space each one uses, and interactively select and delete them to reclaim space.
+
+## Getting Started
+
+- [Installation](https://github.com/voidcosmos/npkill#installation): `npx npkill` (no install needed) or `npm i -g npkill`.
+- [Usage](https://github.com/voidcosmos/npkill#usage): Interactive controls (arrow keys, Space/Del to delete, search mode, multi-select mode).
+- [Options](https://github.com/voidcosmos/npkill#options): Full CLI flag reference (`-d`/`--directory`, `-e`/`--exclude`, `-x`/`--exclude-sensitive`, `--dry-run`, `--json`, `--json-stream`, etc.).
+- [Examples](https://github.com/voidcosmos/npkill#examples): Common invocations for scanning specific paths, excluding directories, and automated deletion.
+
+## Configuration
+
+- [Profiles](https://github.com/voidcosmos/npkill/blob/master/docs/profiles.md): Predefined target sets selectable with `-p`/`--profiles`.
+- [.npkillrc config file](https://github.com/voidcosmos/npkill/blob/master/docs/npkillrc.md): Persistent configuration, loaded from `./.npkillrc` or `~/.npkillrc`.
+- [JSON output](https://github.com/voidcosmos/npkill/blob/master/docs/json-output.md): `--json` and `--json-stream` formats for scripting/automation, with TypeScript interfaces.
+
+## Development
+
+- [Set up locally](https://github.com/voidcosmos/npkill#set-up-locally): Clone, `npm install`, `npm run start`.
+- [Node.js API](https://github.com/voidcosmos/npkill/blob/master/API.md): The `Npkill` interface (`startScan$`, `getSize$`, `delete$`, etc.) for embedding npkill in scripts.
+- [Contributing](https://github.com/voidcosmos/npkill/blob/master/.github/CONTRIBUTING.md): Contribution guidelines.
+
+## Optional
+
+- [Roadmap](https://github.com/voidcosmos/npkill#roadmap): Planned and completed features.
+- [License](https://github.com/voidcosmos/npkill/blob/master/LICENSE): MIT.


### PR DESCRIPTION
This repo doesn't have an [`llms.txt`](https://llmstxt.org) file yet — a small, curated markdown index (title, one-line summary, and grouped links to the docs that matter) that AI coding agents can read to understand a project quickly, instead of having to crawl and guess through the full README and `docs/` tree.

npkill is simple to use interactively but has real depth for scripted/automated use — profiles, a `.npkillrc` config file, a documented JSON/streaming output mode, and a whole separate Node.js API for embedding it in other tools (`API.md`). That's the part an agent is most likely to need help with (e.g. "write a script that deletes node_modules older than 30 days using npkill's JSON output"), and right now it's split across the README and three separate docs files with no single index pointing an agent at the right one.

Content is derived entirely from your existing docs (README sections: Installation, Usage, Options, Examples, JSON Output, Set Up Locally, Roadmap, plus `docs/profiles.md`, `docs/npkillrc.md`, `docs/json-output.md`, and `API.md`) — no new claims, just pointers. Validated against the [llms.txt spec](https://llmstxt.org) with [llms-txt-lint](https://github.com/abyworkings-coder/llms-txt-lint) (disclosure: a small validator tool I maintain — happy to drop that line from the PR if you'd rather not have it).

Totally understand if this isn't something you want to maintain — no worries either way, feel free to close.